### PR TITLE
MOD: bond level

### DIFF
--- a/src/PLMToken.sol
+++ b/src/PLMToken.sol
@@ -182,7 +182,6 @@ contract PLMToken is ERC721Enumerable, IPLMToken {
         );
         // TODO; is it right??
         _mint(to, tokenId);
-        // TODO: event
         return tokenId;
     }
 

--- a/src/interfaces/IPLMToken.sol
+++ b/src/interfaces/IPLMToken.sol
@@ -2,7 +2,6 @@ import {IERC721} from "openzeppelin-contracts/token/ERC721/IERC721.sol";
 import {IERC721Enumerable} from "openzeppelin-contracts/token/ERC721/extensions/IERC721Enumerable.sol";
 
 interface IPLMToken is IERC721, IERC721Enumerable {
-    // TODO: factoryに移す。
     struct CharacterInfo {
         string characterType;
         uint256 fromBlock;


### PR DESCRIPTION
ミント時のblock.numberをcharacterInfoに格納する。
block.numberとこの格納した値の差分を"bond level"として取得する関数を実装。
transfer時にcharacterInfo内のblock.numberが更新されるように_beforeTokenTrasfer()に実装した。