### PR TITLE
Feature/checkpoint

### DIFF
--- a/src/interfaces/IPLMBattleField.sol
+++ b/src/interfaces/IPLMBattleField.sol
@@ -10,6 +10,7 @@ interface IPLMBattleField {
     /// @notice Struct to store player's infomation.
     struct PlayerInfo {
         address addr;
+        uint256 startBlockNum;
         uint256[4] fixedSlots;
         bool[4] slotsUsed;
         RandomSlot randomSlot;
@@ -136,6 +137,8 @@ interface IPLMBattleField {
     function startBattle(
         address aliceAddr,
         address bobAddr,
+        uint256 aliceBlockNum,
+        uint256 bobBlockNum,
         uint256[4] calldata aliceFixedSlots,
         uint256[4] calldata bobFixedSlots
     ) external;

--- a/src/interfaces/IPLMToken.sol
+++ b/src/interfaces/IPLMToken.sol
@@ -11,6 +11,13 @@ interface IPLMToken is IERC721, IERC721Enumerable, IPLMData {
 
     event levelUped(CharacterInfo indexed characterInfo);
 
+    /// @notice when _checkpoint updated
+    event CharacterInfoChanged(
+        uint256 indexed tokenId,
+        CharacterInfo oldCharacterInfo,
+        CharacterInfo newCharacterInfo
+    );
+
     // For debug
     error ErrorWithLog(string reason);
 
@@ -25,23 +32,18 @@ interface IPLMToken is IERC721, IERC721Enumerable, IPLMData {
 
     function getAllCharacterInfo() external returns (CharacterInfo[] calldata);
 
-    function getCharacterInfo(uint256 tokenId)
+    function getCurrentCharacterInfo(uint256 tokenId)
         external
         view
-        returns (CharacterInfo calldata);
+        returns (CharacterInfo memory);
 
-    function updateLevel(uint256 tokenId) external returns (uint8);
+    function updateLevel(uint256 tokenId) external;
 
     function getNecessaryExp(uint256 tokenId) external view returns (uint256);
 
     function setDealer(address newDealer) external;
 
-    function getCurrentCharInfo(uint256 tokenId)
-        external
-        view
-        returns (CharacterInfo memory);
-
-    function getPriorCharInfo(uint256 tokenId, uint256 blockNumber)
+    function getPriorCharacterInfo(uint256 tokenId, uint256 blockNumber)
         external
         view
         returns (CharacterInfo memory);

--- a/src/subcontracts/PLMBattleField.sol
+++ b/src/subcontracts/PLMBattleField.sol
@@ -599,6 +599,8 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard {
     function startBattle(
         address aliceAddr,
         address bobAddr,
+        uint256 aliceBlockNum,
+        uint256 bobBlockNum,
         uint256[4] calldata aliceFixedSlots,
         uint256[4] calldata bobFixedSlots
     ) external readyForBattleStart {
@@ -607,8 +609,14 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard {
 
         // Retrieve character infomation by tokenId in the fixed slots.
         for (uint8 i = 0; i < 4; i++) {
-            aliceCharInfos[i] = token.getCharacterInfo(aliceFixedSlots[i]);
-            bobCharInfos[i] = token.getCharacterInfo(bobFixedSlots[i]);
+            aliceCharInfos[i] = token.getPriorCharacterInfo(
+                aliceFixedSlots[i],
+                aliceBlockNum
+            );
+            bobCharInfos[i] = token.getPriorCharacterInfo(
+                bobFixedSlots[i],
+                bobBlockNum
+            );
         }
 
         // Get level point for both players.
@@ -626,6 +634,7 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard {
 
         PlayerInfo memory aliceInfo = PlayerInfo(
             aliceAddr,
+            aliceBlockNum,
             aliceFixedSlots,
             [false, false, false, false],
             initRandomSlot,
@@ -635,6 +644,7 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard {
         );
         PlayerInfo memory bobInfo = PlayerInfo(
             bobAddr,
+            bobBlockNum,
             bobFixedSlots,
             [false, false, false, false],
             initRandomSlot,
@@ -672,7 +682,10 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard {
         uint16 totalLevel = 0;
         for (uint8 i = 0; i < 4; i++) {
             totalLevel += token
-                .getCharacterInfo(_getFixedSlotTokenId(playerId, i))
+                .getPriorCharacterInfo(
+                    _getFixedSlotTokenId(playerId, i),
+                    playerInfoTable[playerId].startBlockNum
+                )
                 .level;
         }
         return totalLevel;
@@ -718,8 +731,9 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard {
         }
 
         // Retrieve the character information.
-        IPLMToken.CharacterInfo memory charInfo = token.getCharacterInfo(
-            tokenId
+        IPLMToken.CharacterInfo memory charInfo = token.getPriorCharacterInfo(
+            tokenId,
+            playerInfoTable[playerId].startBlockNum
         );
 
         if (choice == Choice.Random) {

--- a/src/subcontracts/PLMData.sol
+++ b/src/subcontracts/PLMData.sol
@@ -124,6 +124,6 @@ contract PLMData is IPLMData {
         pure
         returns (uint256)
     {
-        return charInfo.level**3;
+        return uint256(charInfo.level)**3;
     }
 }

--- a/src/subcontracts/PLMGacha.sol
+++ b/src/subcontracts/PLMGacha.sol
@@ -28,7 +28,7 @@ contract PLMGacha is IPLMGacha, ReentrancyGuard {
                 emit CharacterReceivedByUser(
                     msg.sender,
                     tokenId,
-                    token.getCharacterInfo(tokenId)
+                    token.getCurrentCharacterInfo(tokenId)
                 );
             } catch Error(string memory reason) {
                 token.burn(tokenId);

--- a/test/PLMToken.t.sol
+++ b/test/PLMToken.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import {PLMDealer} from "../src/PLMDealer.sol";
+import {PLMCoin} from "../src/PLMCoin.sol";
+import {PLMToken} from "../src/PLMToken.sol";
+
+import {IPLMCoin} from "../src/interfaces/IPLMCoin.sol";
+import {IPLMToken} from "../src/interfaces/IPLMToken.sol";
+
+contract PLMTokenTest is Test {
+    address polylemmer = address(10);
+    address user = address(11);
+    uint256 maticForEx = 100000 ether;
+    uint32 currentBlock = 0;
+    PLMDealer dealer;
+
+    PLMCoin coinContract;
+    PLMToken tokenContract;
+    IPLMToken token;
+    IPLMCoin coin;
+
+    function setUp() public {
+        // send transaction by deployer
+        vm.startPrank(polylemmer);
+
+        // deploy contract
+        coinContract = new PLMCoin(address(99));
+        coin = IPLMCoin(address(coinContract));
+        tokenContract = new PLMToken(address(99), coin, 100000);
+        token = IPLMToken(address(tokenContract));
+        dealer = new PLMDealer(token, coin);
+
+        // set dealer
+        coin.setDealer(address(dealer));
+        token.setDealer(address(dealer));
+
+        // set block number to be enough length
+        currentBlock = dealer.getStaminaMax() + 1000;
+        vm.roll(currentBlock);
+        vm.stopPrank();
+
+        // initial mint of PLM
+        uint256 ammount = 100000000000000;
+        vm.prank(polylemmer);
+        dealer.mintAdditionalCoin(ammount);
+
+        // send ether to user address
+        vm.deal(user, 10000000 ether);
+        // (user)  charge MATIC and get PLMcoin
+        vm.prank(user);
+        dealer.charge{value: maticForEx}();
+    }
+
+    function testMintWithCheckPoint() public {
+        uint256 tokenId = 1;
+
+        // check empty checkpoint impl
+        PLMToken.CharacterInfo memory checkpointBeforeMint = token
+            .getCurrentCharacterInfo(tokenId);
+
+        assertEq(checkpointBeforeMint.name, "");
+        assertEq(checkpointBeforeMint.characterType, "");
+        assertEq(checkpointBeforeMint.level, 0);
+        assertEq(checkpointBeforeMint.rarity, 0);
+        assertEq(checkpointBeforeMint.abilityIds[0], 0);
+
+        // check impl. of first checkpoint created by mint
+        vm.startPrank(user);
+        coin.approve(address(dealer), dealer.getGachaFee());
+        dealer.gacha("test-mon");
+        PLMToken.CharacterInfo memory checkpointAfterMint = token
+            .getCurrentCharacterInfo(tokenId);
+
+        assertEq(checkpointAfterMint.name, "test-mon");
+        assertEq(checkpointAfterMint.level, 1);
+    }
+
+    function testLevelUpWithCheckPoint() public {
+        uint256 tokenId = 1;
+
+        vm.startPrank(user);
+        // gacha
+        coin.approve(address(dealer), dealer.getGachaFee());
+        dealer.gacha("test-mon");
+
+        // level Up
+        coin.approve(address(token), token.getNecessaryExp(tokenId));
+        token.updateLevel(tokenId);
+
+        assertEq(token.getCurrentCharacterInfo(tokenId).level, 2);
+    }
+
+    function testGetPriorCheckPoint() public {
+        uint256 tokenId = 1;
+
+        vm.startPrank(user);
+        // gacha
+        coin.approve(address(dealer), dealer.getGachaFee());
+        dealer.gacha("test-mon");
+
+        // level Up
+        currentBlock++;
+        vm.roll(currentBlock);
+        coin.approve(address(token), token.getNecessaryExp(tokenId));
+        token.updateLevel(tokenId);
+
+        assertEq(
+            token.getPriorCharacterInfo(tokenId, currentBlock - 1).level,
+            1
+        );
+        assertEq(token.getCurrentCharacterInfo(tokenId).level, 2);
+    }
+
+    function testUpdatelevelSeveralTime() public {
+        uint256 tokenId = 1;
+
+        vm.startPrank(user);
+        // gacha
+        coin.approve(address(dealer), dealer.getGachaFee());
+        dealer.gacha("test-mon");
+
+        // level Up
+        currentBlock++;
+        vm.roll(currentBlock);
+        for (uint256 i = 0; i < 10; i++) {
+            coin.approve(address(token), token.getNecessaryExp(tokenId));
+            token.updateLevel(tokenId);
+        }
+    }
+}


### PR DESCRIPTION
### what have been done
- PLMToken.getCharacterInfo および mapping characterInfos を削除し、checkpointのみをサポートするように変更。
- PLMToken.mint, PLMToken.updateLevel, PLMToken.transferに伴ったcharacterInfoの変更をcheckpointのマッピングに書き込んで行くように変更。
- PLMBattleField内での.getCharacterInfoを、バトル開始時（提案時）のblock.numberを使用した.getPriorInfoで情報取得するように変更。

### validation
test/PLMToken.t.solにて
- Mint, levelup時のcheckpoint書き込み、getCurrentInfo, getPriorInfoの動作確認を実施ずみ。