### PR TITLE
FIX: enpower honest player to ban malicious player.

### DIFF
--- a/src/interfaces/IPLMBattleField.sol
+++ b/src/interfaces/IPLMBattleField.sol
@@ -133,6 +133,8 @@ interface IPLMBattleField {
         bytes32 bindingFactor
     ) external;
 
+    function reportLazyRevealment(PlayerId playerId) external;
+
     function startBattle(
         address aliceAddr,
         address bobAddr,


### PR DESCRIPTION
1. If the honest player has committed and the malicious player has not committed and the commit time limit comes, by calling revealChoice function, the honest player can ban the malicious player as lazy player for commitment. Implemented in modifier.
2. Add function for the honest player to report the malicious player's lazy revealment if it its true. implemented as a function `reportLazyRevealment`.