### PR TITLE
MOD: features for front-side

### DIFF
--- a/src/interfaces/IPLMBattleField.sol
+++ b/src/interfaces/IPLMBattleField.sol
@@ -14,8 +14,25 @@ interface IPLMBattleField {
         uint8 level;
         bytes32 nonce;
         bool nonceSet;
-        bool used;
+        uint8 roundSlotUsed;
         RandomSlotState state;
+    }
+    /// @notice Struct to store the information on the winner and loser of each round
+    struct RoundResult {
+        bool isDraw;
+        PlayerId winner;
+        PlayerId loser;
+        uint32 winnerDamage;
+        uint32 loserDamage;
+    }
+    /// @notice Struct to store the information on the winner and loser of the battle
+    struct BattleResult {
+        uint8 numRounds;
+        bool isDraw;
+        PlayerId winner;
+        PlayerId loser;
+        uint8 winCount;
+        uint8 loseCount;
     }
 
     /// @notice Random slots' state
@@ -38,6 +55,16 @@ interface IPLMBattleField {
         Revealed // 2
     }
 
+    // TODO: さすがに冗長では？？フロントにこのロジックはうつすべき。
+    enum PlayerStateFromFrontSide {
+        Preparing,
+        CharacterSelecting,
+        WaitingForOpponentCommit,
+        Revealing,
+        Revealed,
+        NoNamed
+    }
+
     /// @notice Enum to represent player's choice of the character fighting in the next round.
     enum Choice {
         Fixed1, // 0
@@ -53,10 +80,11 @@ interface IPLMBattleField {
         address addr;
         uint256 startBlockNum;
         uint256[4] fixedSlots;
-        bool[4] slotsUsed;
+        uint8[4] roundFixedSlotUsed;
         RandomSlot randomSlot;
         PlayerState state;
         uint8 winCount;
+        uint8 maxLevelPoint;
         uint8 remainingLevelPoint;
     }
 
@@ -89,7 +117,7 @@ interface IPLMBattleField {
         uint8 levelPoint,
         Choice choice
     );
-    event RoundResult(
+    event RoundCompleted(
         uint8 numRounds,
         bool isDraw,
         PlayerId winner,
@@ -97,7 +125,7 @@ interface IPLMBattleField {
         uint32 winnerDamage,
         uint32 loserDamage
     );
-    event BattleResult(
+    event BattleCompleted(
         uint8 numRounds,
         bool isDraw,
         PlayerId winner,
@@ -165,6 +193,11 @@ interface IPLMBattleField {
         view
         returns (IPLMToken.CharacterInfo memory);
 
+    function getUsedCharacters(PlayerId playerId)
+        external
+        view
+        returns (uint8[5] memory);
+
     function getPlayerIdFromAddress(address playerAddr)
         external
         view
@@ -180,10 +213,28 @@ interface IPLMBattleField {
         view
         returns (uint256);
 
+    function getCurrentRound() external view returns (uint8);
+
+    function getMaxLevelPoint(PlayerId playerId) external view returns (uint8);
+
     function getRemainingLevelPoint(PlayerId playerId)
         external
         view
         returns (uint8);
+
+    function getRoundResult() external view returns (RoundResult[] memory);
+
+    function getBattleResult() external view returns (BattleResult memory);
+
+    function getPlayerStateFromFrontSide(PlayerId fpId)
+        external
+        view
+        returns (PlayerStateFromFrontSide);
+
+    function isPlayerSeedRevealed(PlayerId playerId)
+        external
+        view
+        returns (bool);
 
     ////////////////////////
     ///      SETTER      ///


### PR DESCRIPTION
https://www.notion.so/standard2017cojp/30c7f6eb31054f0fa6717cd5c73c0372
こちらの表にあった関数を実装した。notionに各関数の詳細は適宜記載。
getterばかりなのでtestは書いてません。build通ることは確認済み。

#### getter追加に伴う変更箇所
- storage追加
  - getterで参照するために、RoundResult[] roundResultsを状態変数として追加。
  - 同じく、BattleResult battleResultを状態変数として追加。
  - 上記に伴い、同名のeventをhogeCompleted()に変更。

- PlayerInfo.slotsUsed をbool[4]からuint8[5]に変更した。1-4がfixedSlot, 5がrandomSlot。どのroundで使用したか(numRounds+1)を格納し、未使用の場合は0が格納される。
  - これに伴い、_getFixedSlotUsedFlag()の変数名を_getSlotUsedFlag()へ変更
- PlayerInfoにremainingLevelPointと別にMaxLevelPointを追加。