### PR TITLE
Refactor/token logic

### DIFF
--- a/src/PLMBattleField.sol
+++ b/src/PLMBattleField.sol
@@ -749,7 +749,7 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
         playerInfoTable[playerId].randomSlot.state = RandomSlotState.Committed;
 
         // Generate nonce after player committed the playerSeed.
-        bytes32 nonce = PLMSeeder.generateRandomSlotNonce();
+        bytes32 nonce = PLMSeeder.randomFromBlockHash();
 
         // Emit the event that tells frontend that the randomSlotNonce is generated for the player designated
         // by playerId.

--- a/src/PLMBattleField.sol
+++ b/src/PLMBattleField.sol
@@ -295,9 +295,7 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
         if (
             numRounds == MAX_ROUNDS || diffWinCount > (MAX_ROUNDS - numRounds)
         ) {
-            // This battle ends.
             battleState = BattleState.RoundSettled;
-            _settleBattle();
 
             // Check draw condition.
             bool isDraw = homeWinCount == visitorWinCount;
@@ -317,6 +315,10 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
                 winnerCount,
                 loserCount
             );
+
+            // This battle ends.
+            _settleBattle();
+
             emit BattleCompleted(
                 numRounds - 1,
                 isDraw,
@@ -395,18 +397,12 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
 
     /// @notice Core logic to finalization of the battle.
     function _settleBattle() internal {
-        uint8 homeWinCount = _winCount(PlayerId.Home);
-        uint8 visitorWinCount = _winCount(PlayerId.Visitor);
-
-        // Pay rewards (PLMCoin) to the winner from dealer.
-        if (homeWinCount > visitorWinCount) {
-            // home Wins !!
-            _payRewards(PlayerId.Home, PlayerId.Visitor);
-        } else if (homeWinCount < visitorWinCount) {
-            // visitor Wins !!
-            _payRewards(PlayerId.Visitor, PlayerId.Home);
-        } else {
+        if (battleResult.isDraw) {
+            // this battle is draw. pay rewards to both of players from dealer.
             _payRewardsDraw();
+        } else {
+            // Pay rewards (PLMCoin) to the winner from dealer.
+            _payRewards(battleResult.winner, battleResult.loser);
         }
 
         // Update the proposal state.

--- a/src/PLMCoin.sol
+++ b/src/PLMCoin.sol
@@ -13,20 +13,17 @@ contract PLMCoin is ERC20, IPLMCoin {
     /// @notice contract address of the dealer of polylemma.
     address public dealer;
 
-    bool dealerIsSet = false;
-
     constructor() ERC20("polylemma", "PLM") {
         polylemmers = msg.sender;
     }
 
     modifier onlyDealer() {
-        require(dealerIsSet, "dealer has not been set.");
-        require(msg.sender == dealer, "sender is not dealer.");
+        require(msg.sender == dealer, "sender != dealer");
         _;
     }
 
     modifier onlyPolylemmers() {
-        require(msg.sender == polylemmers, "sender is not deployer.");
+        require(msg.sender == polylemmers, "sender != deployer");
         _;
     }
 
@@ -49,7 +46,6 @@ contract PLMCoin is ERC20, IPLMCoin {
     ///         ("polylemmers" is contract deployer's address.)
     function setDealer(address _dealer) external onlyPolylemmers {
         dealer = _dealer;
-        dealerIsSet = true;
     }
 
     //////////////////////////

--- a/src/PLMDealer.sol
+++ b/src/PLMDealer.sol
@@ -74,7 +74,6 @@ contract PLMDealer is PLMGacha, IPLMDealer {
     ///      - When the current block number is less than max stamina point, this function return max stamina.
     function _currentStamina(address player) internal view returns (uint8) {
         if (block.number < STAMINA_MAX) {
-            // TODO:
             return STAMINA_MAX;
         } else if (block.number > staminaFromBlock[player]) {
             return
@@ -83,7 +82,6 @@ contract PLMDealer is PLMGacha, IPLMDealer {
                         STAMINA_RESTORE_SPEED).min(STAMINA_MAX)
                 );
         } else {
-            // TODO
             return 0;
         }
     }

--- a/src/PLMDealer.sol
+++ b/src/PLMDealer.sol
@@ -56,15 +56,15 @@ contract PLMDealer is PLMGacha, IPLMDealer {
     }
 
     modifier onlyPolylemmers() {
-        require(msg.sender == polylemmers, "sender is not polylemmers");
+        require(msg.sender == polylemmers, "sender != polylemmers");
         _;
     }
     modifier onlyMatchOrganizer() {
-        require(msg.sender == matchOrganizer, "sender is not matchOrganizer");
+        require(msg.sender == matchOrganizer, "sender != matchOrganizer");
         _;
     }
     modifier onlyBattleField() {
-        require(msg.sender == battleField, "sender is not battleField");
+        require(msg.sender == battleField, "sender != battleField");
         _;
     }
 

--- a/src/PLMDealer.sol
+++ b/src/PLMDealer.sol
@@ -218,6 +218,12 @@ contract PLMDealer is PLMGacha, IPLMDealer {
     /// FUNCTIONS ABOUT SUBSCRIPTION ///
     ////////////////////////////////////
 
+    function _extendSubscPeriod(address account) internal {
+        subscExpiredBlock[account] =
+            getSubscExpiredBlock(account).max(block.number) +
+            SUBSC_UNIT_PERIOD_BLOCK_NUM;
+    }
+
     /// @notice Function to return whether the account's subscription is expired or not.
     function subscIsExpired(address account) external view returns (bool) {
         return block.number > getSubscExpiredBlock(account);
@@ -287,12 +293,6 @@ contract PLMDealer is PLMGacha, IPLMDealer {
 
     function getSubscUnitPeriodBlockNum() external pure returns (uint256) {
         return SUBSC_UNIT_PERIOD_BLOCK_NUM;
-    }
-
-    function _extendSubscPeriod(address account) internal {
-        subscExpiredBlock[account] =
-            getSubscExpiredBlock(account).max(block.number) +
-            SUBSC_UNIT_PERIOD_BLOCK_NUM;
     }
 
     //////////////////////////////////

--- a/src/PLMDealer.sol
+++ b/src/PLMDealer.sol
@@ -42,9 +42,6 @@ contract PLMDealer is PLMGacha, IPLMDealer {
     /// @notice admin's address
     address polylemmers;
 
-    bool matchOrganizerIsSet = false;
-    bool battleFieldIsSet = false;
-
     /// @notice Mapping from each account to one's subscription expired block number.
     mapping(address => uint256) subscExpiredBlock;
 
@@ -63,12 +60,10 @@ contract PLMDealer is PLMGacha, IPLMDealer {
         _;
     }
     modifier onlyMatchOrganizer() {
-        require(matchOrganizerIsSet, "matchOrganizer has not been set.");
         require(msg.sender == matchOrganizer, "sender is not matchOrganizer");
         _;
     }
     modifier onlyBattleField() {
-        require(battleFieldIsSet, "battleField has not been set.");
         require(msg.sender == battleField, "sender is not battleField");
         _;
     }
@@ -108,7 +103,7 @@ contract PLMDealer is PLMGacha, IPLMDealer {
         uint256 totalAmount = address(this).balance;
 
         // Check that withdrawal is possible.
-        require(amount <= totalAmount, "cannot withdraw over total balance.");
+        require(amount <= totalAmount, "cannot withdraw in excess of balance");
 
         // Execute withdrawal.
         (bool success, ) = payable(dealer).call{value: amount}("");
@@ -154,10 +149,6 @@ contract PLMDealer is PLMGacha, IPLMDealer {
 
     /// @notice need approvement of coin to dealer
     function restoreFullStamina(address player) external nonReentrant {
-        require(
-            coin.balanceOf(msg.sender) >= 1,
-            "player does not have enough coin"
-        );
         require(
             _currentStamina(player) < STAMINA_MAX,
             "player's stamina is full"
@@ -236,9 +227,6 @@ contract PLMDealer is PLMGacha, IPLMDealer {
 
     /// @notice Function to extend subscription period. Need approvement of coin to dealer
     function extendSubscPeriod() external {
-        // Check the user owns enough PLMCoin to extend one's subscription period.
-        require(coin.balanceOf(msg.sender) >= SUBSC_FEE_PER_UNIT_PERIOD);
-
         uint256 currentExpiredBlock = getSubscExpiredBlock(msg.sender);
 
         // TODO: modify here from transfer to safeTransfer.
@@ -395,7 +383,6 @@ contract PLMDealer is PLMGacha, IPLMDealer {
         external
         onlyPolylemmers
     {
-        matchOrganizerIsSet = true;
         matchOrganizer = _matchOrganizer;
     }
 
@@ -403,7 +390,6 @@ contract PLMDealer is PLMGacha, IPLMDealer {
     /// @dev   This function must be called when initializing contracts by the deployer manually. ("polylemmers" is contract deployer's address.)
     ///        "battleField" address is stored in this contract to make some functions able to be called from only battleField.
     function setBattleField(address _battleField) external onlyPolylemmers {
-        battleFieldIsSet = true;
         battleField = _battleField;
     }
 }

--- a/src/PLMMatchOrganizer.sol
+++ b/src/PLMMatchOrganizer.sol
@@ -43,12 +43,12 @@ contract PLMMatchOrganizer is IPLMMatchOrganizer, ReentrancyGuard, IERC165 {
     }
 
     modifier onlyPolylemmers() {
-        require(msg.sender == polylemmers, "sender is not polylemmers");
+        require(msg.sender == polylemmers, "sender != polylemmers");
         _;
     }
 
     modifier blockNumberIsPositive() {
-        require(block.number > 0, "block number is zero.");
+        require(block.number > 0, "block.number == 0");
         _;
     }
 
@@ -56,16 +56,13 @@ contract PLMMatchOrganizer is IPLMMatchOrganizer, ReentrancyGuard, IERC165 {
     modifier subscribed() {
         require(
             !dealer.subscIsExpired(msg.sender),
-            "sender's subscription is expired."
+            "sender's subscription is expired"
         );
         _;
     }
 
     modifier onlyBattleField() {
-        require(
-            msg.sender == address(battleField),
-            "sender is not battleField."
-        );
+        require(msg.sender == address(battleField), "sender != battleField.");
         _;
     }
 
@@ -129,14 +126,14 @@ contract PLMMatchOrganizer is IPLMMatchOrganizer, ReentrancyGuard, IERC165 {
         // Prevent the proposer from proposing twice or more.
         require(
             matchStates[msg.sender] == MatchState.NotInvolved,
-            "proposing, or in battle."
+            "Player can't create proposal"
         );
 
         for (uint256 slotIdx = 0; slotIdx < FIXED_SLOTS_NUM; slotIdx++) {
             // Check that the proposed fixed slots tokens are owned by the proposer.
             require(
                 msg.sender == token.ownerOf(fixedSlots[slotIdx]),
-                "The proposer is not the owner of the character."
+                "Proposer != owner of the character."
             );
 
             // Check that the token was minted in the past.
@@ -147,7 +144,7 @@ contract PLMMatchOrganizer is IPLMMatchOrganizer, ReentrancyGuard, IERC165 {
                         block.number - 1
                     )
                     .fromBlock < block.number,
-                "token just minted now cannot be used."
+                "Token just minted now cannot be used"
             );
         }
 
@@ -194,13 +191,13 @@ contract PLMMatchOrganizer is IPLMMatchOrganizer, ReentrancyGuard, IERC165 {
         // Check that the player designated by the address is truely a proposer.
         require(
             matchStates[proposer] == MatchState.Proposed,
-            "called address is not in proposal"
+            "Designated proposer isn't invalid"
         );
 
         // Check that the challenger is not a proposer.
         require(
             matchStates[msg.sender] == MatchState.NotInvolved,
-            "sender is in Battle or proposing."
+            "Sender can't request challenge"
         );
 
         // Check that the proposer is subscribed.
@@ -214,7 +211,7 @@ contract PLMMatchOrganizer is IPLMMatchOrganizer, ReentrancyGuard, IERC165 {
             // Check that the fixed slots tokens are owned by the visitor.
             require(
                 msg.sender == token.ownerOf(fixedSlots[slotIdx]),
-                "submitted character is not owned by the sender."
+                "sender != owner of the submitted character"
             );
 
             // Check that the token is minted in the past.
@@ -225,7 +222,7 @@ contract PLMMatchOrganizer is IPLMMatchOrganizer, ReentrancyGuard, IERC165 {
                         block.number - 1
                     )
                     .fromBlock < block.number,
-                "token just minted now cannot used in battle."
+                "Token just minted now cannot used"
             );
         }
 
@@ -254,7 +251,7 @@ contract PLMMatchOrganizer is IPLMMatchOrganizer, ReentrancyGuard, IERC165 {
         require(
             visitorTotalLevel >= proposal.lowerBound &&
                 visitorTotalLevel <= proposal.upperBound,
-            "not satisfy level condition."
+            "Violate level condition"
         );
 
         // pay stamina
@@ -335,7 +332,7 @@ contract PLMMatchOrganizer is IPLMMatchOrganizer, ReentrancyGuard, IERC165 {
             IERC165(_battleField).supportsInterface(
                 type(IPLMBattleField).interfaceId
             ),
-            "Given contract doesn't support IPLMBattleField."
+            "Given contract doesn't support IPLMBattleField"
         );
         battleField = IPLMBattleField(_battleField);
     }

--- a/src/PLMToken.sol
+++ b/src/PLMToken.sol
@@ -93,12 +93,12 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
     ///         The character can be enhanced up to the twice as much level as its normal level.
     function _calcBondLevel(
         uint8 level,
-        uint256 startBlock,
-        uint256 lastBlock
+        uint256 fromBlock,
+        uint256 toBlock
     ) internal pure returns (uint32) {
         // TODO: we should increase this factor.
         uint256 blockPeriod = 50;
-        uint32 ownershipPeriod = uint32((lastBlock - startBlock) / blockPeriod);
+        uint32 ownershipPeriod = uint32((toBlock - fromBlock) / blockPeriod);
         return ownershipPeriod < level * 2 ? ownershipPeriod : level * 2;
     }
 

--- a/src/PLMToken.sol
+++ b/src/PLMToken.sol
@@ -22,14 +22,14 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
     using Strings for uint8;
     using Strings for uint256;
 
+    /// @notice interface to the coin of polylemma.
     IPLMCoin coin;
 
+    /// @notice admin's address
     address polylemmers;
-    address dealer;
-    address enhancer;
 
-    // FIXME: this parameter name should start from lower case character.
-    bool dealerIsSet;
+    /// @notice contract address of the dealer of polylemma.
+    address dealer;
 
     uint256 maxSupply;
 
@@ -52,34 +52,28 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
     mapping(uint256 => mapping(uint32 => CharInfoCheckpoint)) charInfoCheckpoints;
 
     constructor(IPLMCoin _coin, uint256 _maxSupply) ERC721("Polylemma", "PLM") {
-        polylemmers = msg.sender;
         coin = _coin;
         maxSupply = _maxSupply;
-        dealerIsSet = false;
+        polylemmers = msg.sender;
     }
 
     modifier onlyPolylemmers() {
-        require(
-            msg.sender == polylemmers,
-            "Permission denied. Sender is not polylemmers."
-        );
+        require(msg.sender == polylemmers, "Sender != polylemmers");
         _;
     }
 
     modifier onlyDealer() {
-        require(dealerIsSet, "dealer has not been set.");
-        require(
-            msg.sender == dealer,
-            "Permission denied. Sender is not dealer."
-        );
+        require(msg.sender == dealer, "Sender != dealer");
         _;
     }
 
+    /// TODO: checkPointableにする情報は一部でじゅうぶん。
     /// @notice core logic of levelup.
     /// @dev Because character info has changed by levelup, the new character info
     ///      is written into checkpoints in this function.
     function _updateLevel(uint256 tokenId) internal {
         uint32 checkNum = numCharInfoCheckpoints[tokenId];
+
         CharacterInfo memory charInfoOld = charInfoCheckpoints[tokenId][
             checkNum - 1
         ].charInfo;
@@ -607,7 +601,6 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
     ////////////////////////
 
     function setDealer(address newDealer) external {
-        dealerIsSet = true;
         dealer = newDealer;
     }
 

--- a/src/PLMToken.sol
+++ b/src/PLMToken.sol
@@ -333,24 +333,10 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
 
     /// @notice increment level with consuming his coin
     function updateLevel(uint256 tokenId) external nonReentrant {
-        require(
-            msg.sender == ownerOf(tokenId),
-            "Permission denied. Sender is not owner of this token"
-        );
-        require(getCurrentCharacterInfo(tokenId).level <= 255, "level is max.");
+        require(msg.sender == ownerOf(tokenId), "sender is not owner");
+        require(getCurrentCharacterInfo(tokenId).level <= 255, "level max");
 
         uint256 necessaryExp = _necessaryExp(tokenId);
-        // whether user have delgated this contract to spend coin for levelup
-        require(
-            coin.allowance(msg.sender, address(this)) >= necessaryExp,
-            "not enough Coin allowance"
-        );
-        // whether user have ehough coin to increment level
-        require(
-            coin.balanceOf(msg.sender) >= necessaryExp,
-            "not enough coin to update level"
-        );
-
         try coin.transferFrom(msg.sender, polylemmers, necessaryExp) {
             _updateLevel(tokenId);
         } catch Error(string memory reason) {
@@ -553,10 +539,7 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
         returns (CharacterInfo memory)
     {
         CharacterInfo memory dummyInfo = CharacterInfo("", 0, 0, "", 0, 0, [0]);
-        require(
-            blockNumber < block.number,
-            "PLMToken::getPriorCharInfo: not yet determined"
-        );
+        require(blockNumber < block.number, "blockNumber lager than latest");
 
         (uint32 index, bool found) = _searchCharInfoCheckpointIdx(
             tokenId,
@@ -580,10 +563,7 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
         returns (uint256)
     {
         uint256 dummyTotalSupply = 0;
-        require(
-            blockNumber < block.number,
-            "PLMToken::getPriorTokenSupply: not yet determined"
-        );
+        require(blockNumber < block.number, "blockNumber lager than latest");
 
         (uint32 index, bool found) = _searchTotalSupplyCheckpointIdx(
             blockNumber

--- a/src/PLMToken.sol
+++ b/src/PLMToken.sol
@@ -187,6 +187,8 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
         return (lower, true);
     }
 
+    // function _checkpoint(WhichCheckpoint which, uint256 index) returns (uint256 cpFromBlock) {}
+
     /// @notice Function to mint new PLMToken to the account (to).
     /// @dev 1. generate seed to assign attirbutes to the minted token using Seeder.
     ///      2. write checkpoint of total supply.
@@ -556,7 +558,7 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
         }
     }
 
-    function getImgURI(uint256 imgId) external returns (string memory) {
+    function getImgURI(uint256 imgId) external view returns (string memory) {
         return _imgURI(imgId);
     }
 

--- a/src/PLMToken.sol
+++ b/src/PLMToken.sol
@@ -67,7 +67,6 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
         _;
     }
 
-    /// TODO: checkPointableにする情報は一部でじゅうぶん。
     /// @notice core logic of levelup.
     /// @dev Because character info has changed by levelup, the new character info
     ///      is written into checkpoints in this function.
@@ -78,13 +77,13 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
             checkNum - 1
         ].charInfo;
         CharacterInfo memory charInfoNew = CharacterInfo(
-            charInfoOld.name,
-            charInfoOld.imgId,
-            charInfoOld.fromBlock,
-            charInfoOld.characterType,
             charInfoOld.level + 1,
             charInfoOld.rarity,
-            charInfoOld.attributeIds
+            charInfoOld.imgId,
+            charInfoOld.fromBlock,
+            charInfoOld.attributeIds,
+            charInfoOld.name,
+            charInfoOld.characterType
         );
 
         _writeCharInfoCheckpoint(tokenId, checkNum, charInfoOld, charInfoNew);
@@ -200,18 +199,18 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
         );
         string[] memory characterTypes = _characterTypes();
         CharacterInfo memory mintedCharInfo = CharacterInfo(
-            name,
-            seed.imgId,
-            block.number,
-            characterTypes[seed.characterType],
             1,
             _calcRarity([seed.attribute]),
-            [seed.attribute]
+            seed.imgId,
+            block.number,
+            [seed.attribute],
+            name,
+            characterTypes[seed.characterType]
         );
 
         // write character info checkpoint
         uint32 charInfoCheckNum = numCharInfoCheckpoints[tokenId];
-        CharacterInfo memory dummyInfo = CharacterInfo("", 0, 0, "", 0, 0, [0]);
+        CharacterInfo memory dummyInfo = CharacterInfo(0, 0, 0, 0, [0], "", "");
         _writeCharInfoCheckpoint(
             tokenId,
             charInfoCheckNum,
@@ -244,13 +243,13 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
             charInfoCheckNum - 1
         ].charInfo;
         CharacterInfo memory charInfoNew = CharacterInfo(
-            charInfoOld.name,
-            charInfoOld.imgId,
-            block.number,
-            charInfoOld.characterType,
             charInfoOld.level,
             charInfoOld.rarity,
-            charInfoOld.attributeIds
+            charInfoOld.imgId,
+            block.number,
+            charInfoOld.attributeIds,
+            charInfoOld.name,
+            charInfoOld.characterType
         );
 
         _writeCharInfoCheckpoint(
@@ -519,7 +518,7 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
         view
         returns (CharacterInfo memory)
     {
-        CharacterInfo memory dummyInfo = CharacterInfo("", 0, 0, "", 0, 0, [0]);
+        CharacterInfo memory dummyInfo = CharacterInfo(0, 0, 0, 0, [0], "", "");
         uint32 nCharInfoCheckpoints = numCharInfoCheckpoints[tokenId];
         return
             nCharInfoCheckpoints > 0
@@ -540,7 +539,7 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
         view
         returns (CharacterInfo memory)
     {
-        CharacterInfo memory dummyInfo = CharacterInfo("", 0, 0, "", 0, 0, [0]);
+        CharacterInfo memory dummyInfo = CharacterInfo(0, 0, 0, 0, [0], "", "");
         require(blockNumber < block.number, "blockNumber lager than latest");
 
         (uint32 index, bool found) = _searchCharInfoCheckpointIdx(

--- a/src/PLMToken.sol
+++ b/src/PLMToken.sol
@@ -196,7 +196,7 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
             tokenId,
             IPLMData(address(this))
         );
-        string[] memory characterTypes = getCharacterTypes();
+        string[] memory characterTypes = _characterTypes();
         CharacterInfo memory mintedCharInfo = CharacterInfo(
             name,
             seed.imgId,

--- a/src/PLMToken.sol
+++ b/src/PLMToken.sol
@@ -109,6 +109,7 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
         view
         returns (uint32, bool)
     {
+        /// from here ////
         if (numTotalSupplyCheckpoints == 0) {
             return (0, false);
         }
@@ -150,6 +151,7 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
         returns (uint32, bool)
     {
         uint32 nCharInfoCheckpoints = numCharInfoCheckpoints[tokenId];
+        /// from here ////
         if (nCharInfoCheckpoints == 0) {
             return (0, false);
         }
@@ -192,7 +194,7 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
         uint256 tokenId,
         bytes32 name
     ) internal returns (uint256) {
-        PLMSeeder.Seed memory seed = PLMSeeder.generateSeed(
+        PLMSeeder.Seed memory seed = PLMSeeder.generateTokenSeed(
             tokenId,
             IPLMData(address(this))
         );

--- a/src/PLMToken.sol
+++ b/src/PLMToken.sol
@@ -143,6 +143,8 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
         return (lower, true);
     }
 
+    /// 関数の引数にbytesForFunctionSelector   bytes4(keccak256(“func_name(type1,type2)”))
+    /// (Bool success, bytes returnval) = call(functionSelector, 引数たち)
     /// @notice Run binary search in character info checkpoints.
     function _searchCharInfoCheckpointIdx(uint256 tokenId, uint256 blockNumber)
         internal
@@ -334,7 +336,7 @@ contract PLMToken is ERC721Enumerable, PLMData, IPLMToken, ReentrancyGuard {
 
     /// @notice increment level with consuming his coin
     function updateLevel(uint256 tokenId) external nonReentrant {
-        require(msg.sender == ownerOf(tokenId), "sender is not owner");
+        require(msg.sender == ownerOf(tokenId), "sender != owner");
         require(getCurrentCharacterInfo(tokenId).level <= 255, "level max");
 
         uint256 necessaryExp = _necessaryExp(tokenId);

--- a/src/interfaces/IPLMData.sol
+++ b/src/interfaces/IPLMData.sol
@@ -3,7 +3,6 @@ interface IPLMData {
     ///      STRUCTS     ///
     ////////////////////////
 
-    // TODO: member変数の入れ替え
     struct CharacterInfo {
         uint8 level;
         uint8 rarity;

--- a/src/interfaces/IPLMData.sol
+++ b/src/interfaces/IPLMData.sol
@@ -5,13 +5,13 @@ interface IPLMData {
 
     // TODO: member変数の入れ替え
     struct CharacterInfo {
-        bytes32 name;
-        uint256 imgId;
-        uint256 fromBlock;
-        string characterType;
         uint8 level;
         uint8 rarity;
+        uint256 imgId;
+        uint256 fromBlock;
         uint8[1] attributeIds;
+        bytes32 name;
+        string characterType;
     }
 
     ////////////////////////

--- a/src/interfaces/IPLMData.sol
+++ b/src/interfaces/IPLMData.sol
@@ -3,6 +3,7 @@ interface IPLMData {
     ///      STRUCTS     ///
     ////////////////////////
 
+    // TODO: member変数の入れ替え
     struct CharacterInfo {
         bytes32 name;
         uint256 imgId;

--- a/src/interfaces/IPLMToken.sol
+++ b/src/interfaces/IPLMToken.sol
@@ -3,6 +3,11 @@ import {IERC721Enumerable} from "openzeppelin-contracts/token/ERC721/extensions/
 import {IPLMData} from "./IPLMData.sol";
 
 interface IPLMToken is IERC721, IERC721Enumerable, IPLMData {
+    /// @notice Enum to represent battle's state.
+    enum WhichCheckpoints {
+        CharInfo, // 0
+        TotalSupply, // 1
+    }
     /// @notice A checkpoint for marking change of characterInfo from a given block.
     struct CharInfoCheckpoint {
         uint256 fromBlock;

--- a/src/interfaces/IPLMToken.sol
+++ b/src/interfaces/IPLMToken.sol
@@ -3,10 +3,10 @@ import {IERC721Enumerable} from "openzeppelin-contracts/token/ERC721/extensions/
 import {IPLMData} from "./IPLMData.sol";
 
 interface IPLMToken is IERC721, IERC721Enumerable, IPLMData {
-    /// @notice Enum to represent battle's state.
+    /// @notice Enum to represent which checkpoint is reffered
     enum WhichCheckpoints {
         CharInfo, // 0
-        TotalSupply, // 1
+        TotalSupply // 1
     }
     /// @notice A checkpoint for marking change of characterInfo from a given block.
     struct CharInfoCheckpoint {

--- a/src/lib/PLMSeeder.sol
+++ b/src/lib/PLMSeeder.sol
@@ -11,28 +11,58 @@ library PLMSeeder {
         uint8 attribute;
     }
 
+    function _randomFromTokenId(uint256 tokenId)
+        internal
+        view
+        returns (uint256)
+    {
+        return
+            uint256(
+                keccak256(
+                    abi.encodePacked(blockhash(block.number - 1), tokenId)
+                )
+            );
+    }
+
+    /// @notice Only the cumulativeOdds stores cumulative probabilities.
+    /// This function calc Id from the array with pseudoRandomness
+    function _matchRandomnessWithOdds(
+        uint256 pseudoRandomness,
+        uint8[] memory cumulativeOdds
+    ) internal pure returns (uint8) {
+        uint8 sumOdds = cumulativeOdds[cumulativeOdds.length - 1];
+        uint256 p = pseudoRandomness % sumOdds;
+        if (p < cumulativeOdds[0]) return 0;
+        for (uint8 i = 1; i < cumulativeOdds.length; i++) {
+            if (cumulativeOdds[i - 1] <= p && p < cumulativeOdds[i]) {
+                return i;
+            }
+        }
+        return 0;
+    }
+
+    //////////////////////////
+    ///  SEEDER FUNCTIONS  ///
+    //////////////////////////
+
     /// @notice generate seeds for character mint
     /// @dev generate seeds of traits from current-block's hash for to mint character
     /// @param tokenId tokenId to be minted
     /// @return Seed the struct of trait seed that is indexId of trait array
-    function generateSeed(uint256 tokenId, IPLMData data)
+    function generateTokenSeed(uint256 tokenId, IPLMData data)
         external
         view
         returns (Seed memory)
     {
         // TODO: 画像は属性や特性と比較して総数が多いため、現行の実装を踏襲するとものによって排出確率を変更する実装が汚くなってしまうから、一旦一様分布で対応する。
-        uint256 pseudoRandomnessImg = _generateRandomnessFromBlockHash(tokenId);
+        uint256 pseudoRandomnessImg = _randomFromTokenId(tokenId);
         uint256 numImg = data.getNumImg();
 
-        uint256 pseudoRandomnessType = _generateRandomnessFromBlockHash(
-            tokenId + 1
-        );
+        uint256 pseudoRandomnessType = _randomFromTokenId(tokenId + 1);
         uint8[] memory cumulativeCharacterTypeOdds = data
             .getCumulativeCharacterTypeOdds();
 
-        uint256 pseudoRandomnessAttribute = _generateRandomnessFromBlockHash(
-            tokenId + 2
-        );
+        uint256 pseudoRandomnessAttribute = _randomFromTokenId(tokenId + 2);
         uint8[] memory cumulativeAttributeOdds = data
             .getCumulativeAttributeOdds();
 
@@ -52,23 +82,13 @@ library PLMSeeder {
 
     /// @notice generate nonce to be used as input of hash for randomSlotTokenId
     /// @dev generate nonce to be used as input of hash for randomSlotTokenId
-    /// TODO: 関数名変える
-    function generateRandomSlotNonce() external view returns (bytes32) {
+    function randomFromBlockHash() external view returns (bytes32) {
         return keccak256(abi.encodePacked(blockhash(block.number - 1)));
     }
 
-    function _generateRandomnessFromBlockHash(uint256 tokenId)
-        internal
-        view
-        returns (uint256)
-    {
-        return
-            uint256(
-                keccak256(
-                    abi.encodePacked(blockhash(block.number - 1), tokenId)
-                )
-            );
-    }
+    ////////////////////////
+    ///      GETTERS     ///
+    ////////////////////////
 
     /// @notice create tokenId for randomslot without being searched
     /// @dev create tokenId for randomslot without being searched
@@ -83,22 +103,5 @@ library PLMSeeder {
             keccak256(abi.encodePacked(nonce, playerSeed))
         ) % totalSupply) + 1;
         return tokenId;
-    }
-
-    /// @notice Only the cumulativeOdds stores cumulative probabilities.
-    /// This function calc Id from the array with pseudoRandomness
-    function _matchRandomnessWithOdds(
-        uint256 pseudoRandomness,
-        uint8[] memory cumulativeOdds
-    ) internal pure returns (uint8) {
-        uint8 sumOdds = cumulativeOdds[cumulativeOdds.length - 1];
-        uint256 p = pseudoRandomness % sumOdds;
-        if (p < cumulativeOdds[0]) return 0;
-        for (uint8 i = 1; i < cumulativeOdds.length; i++) {
-            if (cumulativeOdds[i - 1] <= p && p < cumulativeOdds[i]) {
-                return i;
-            }
-        }
-        return 0;
     }
 }

--- a/src/subcontracts/PLMData.sol
+++ b/src/subcontracts/PLMData.sol
@@ -42,6 +42,10 @@ contract PLMData is IPLMData {
         return uint256(PLMSeeder.generateRandomSlotNonce()) % 100 < x;
     }
 
+    function _characterTypes() internal view returns (string[] memory) {
+        return characterTypes;
+    }
+
     function _typeCompatibility(
         string calldata playerType,
         string calldata enemyType

--- a/src/subcontracts/PLMData.sol
+++ b/src/subcontracts/PLMData.sol
@@ -5,15 +5,8 @@ import {PLMSeeder} from "../lib/PLMSeeder.sol";
 import {IPLMData} from "../interfaces/IPLMData.sol";
 
 contract PLMData is IPLMData {
-    // TODO: monsterblocksのmonster名で仮置きした
     // TODO: 入替可能なようにconstructorで初期化&setHogeで入替可能にするべき
-    string[] public characterTypes = [
-        "Fire",
-        "Grass",
-        "Water"
-        // "dark",
-        // "light"
-    ];
+    string[] public characterTypes = ["Fire", "Grass", "Water"];
 
     /// @notice ratio of probability of type occurrence
     uint8[] public characterTypeOdds = [1, 1, 1];
@@ -302,11 +295,6 @@ contract PLMData is IPLMData {
         override
         returns (uint8[] memory)
     {
-        require(
-            characterTypes.length == characterTypeOdds.length,
-            "characterTypes.length != characterTypeOdds.length"
-        );
-
         uint256 numCharacterTypes = characterTypes.length;
         uint8[] memory cumulativeCharacterTypeOdds = new uint8[](
             numCharacterTypes

--- a/src/subcontracts/PLMData.sol
+++ b/src/subcontracts/PLMData.sol
@@ -30,6 +30,64 @@ contract PLMData is IPLMData {
     /// @notice Progressive taxation of coin issuance through billing
     uint256[] public poolingPercentageTable = [5, 10, 20, 23, 33, 40, 45];
 
+    function _mulFloat(
+        uint256 x,
+        uint256 denominator,
+        uint256 numerator
+    ) internal pure returns (uint32) {
+        return uint32((x * denominator) / numerator);
+    }
+
+    function _rate(uint8 x) internal view returns (bool) {
+        return uint256(PLMSeeder.generateRandomSlotNonce()) % 100 < x;
+    }
+
+    function _typeCompatibility(
+        string calldata playerType,
+        string calldata enemyType
+    ) internal pure returns (uint8, uint8) {
+        bytes32 playerTypeBytes = keccak256(abi.encodePacked(playerType));
+        bytes32 enemyTypeBytes = keccak256(abi.encodePacked(enemyType));
+        bytes32 fire = keccak256(abi.encodePacked("fire"));
+        bytes32 grass = keccak256(abi.encodePacked("grass"));
+        bytes32 water = keccak256(abi.encodePacked("water"));
+        if (playerTypeBytes == enemyTypeBytes) {
+            return (1, 1);
+        } else if (
+            (playerTypeBytes == fire && enemyTypeBytes == grass) ||
+            (playerTypeBytes == grass && enemyTypeBytes == water) ||
+            (playerTypeBytes == water && enemyTypeBytes == fire)
+        ) {
+            return (12, 10);
+        } else if (
+            (enemyTypeBytes == fire && playerTypeBytes == grass) ||
+            (enemyTypeBytes == grass && playerTypeBytes == water) ||
+            (enemyTypeBytes == water && playerTypeBytes == fire)
+        ) {
+            return (8, 10);
+        } else {
+            // TODO: Error handling
+            return (1, 1);
+        }
+    }
+
+    function _calcRarity(uint8[1] memory attributeIds)
+        internal
+        view
+        returns (uint8)
+    {
+        return attributeRarities[attributeIds[0]];
+    }
+
+    /// @dev This logic is derived from Pokemon
+    function _calcNecessaryExp(CharacterInfo memory charInfo)
+        internal
+        pure
+        returns (uint256)
+    {
+        return uint256(charInfo.level)**2;
+    }
+
     /// @notice function to simulate the battle and return back result to BattleField contract.
     function _calcDamage(
         uint8 numRounds,
@@ -200,7 +258,7 @@ contract PLMData is IPLMData {
 
     /// @notice get the percentage of pooling of PLMCoins minted when player charged MATIC.
     function getPoolingPercentage(uint256 amount)
-        public
+        external
         view
         returns (uint256)
     {
@@ -222,7 +280,7 @@ contract PLMData is IPLMData {
     }
 
     function getCharacterTypes()
-        public
+        external
         view
         override
         returns (string[] memory)
@@ -310,63 +368,5 @@ contract PLMData is IPLMData {
 
     function getNumImg() external view returns (uint256) {
         return numImg;
-    }
-
-    function _mulFloat(
-        uint256 x,
-        uint256 denominator,
-        uint256 numerator
-    ) internal pure returns (uint32) {
-        return uint32((x * denominator) / numerator);
-    }
-
-    function _rate(uint8 x) internal view returns (bool) {
-        return uint256(PLMSeeder.generateRandomSlotNonce()) % 100 < x;
-    }
-
-    function _typeCompatibility(
-        string calldata playerType,
-        string calldata enemyType
-    ) internal pure returns (uint8, uint8) {
-        bytes32 playerTypeBytes = keccak256(abi.encodePacked(playerType));
-        bytes32 enemyTypeBytes = keccak256(abi.encodePacked(enemyType));
-        bytes32 fire = keccak256(abi.encodePacked("fire"));
-        bytes32 grass = keccak256(abi.encodePacked("grass"));
-        bytes32 water = keccak256(abi.encodePacked("water"));
-        if (playerTypeBytes == enemyTypeBytes) {
-            return (1, 1);
-        } else if (
-            (playerTypeBytes == fire && enemyTypeBytes == grass) ||
-            (playerTypeBytes == grass && enemyTypeBytes == water) ||
-            (playerTypeBytes == water && enemyTypeBytes == fire)
-        ) {
-            return (12, 10);
-        } else if (
-            (enemyTypeBytes == fire && playerTypeBytes == grass) ||
-            (enemyTypeBytes == grass && playerTypeBytes == water) ||
-            (enemyTypeBytes == water && playerTypeBytes == fire)
-        ) {
-            return (8, 10);
-        } else {
-            // TODO: Error handling
-            return (1, 1);
-        }
-    }
-
-    function _calcRarity(uint8[1] memory attributeIds)
-        internal
-        view
-        returns (uint8)
-    {
-        return attributeRarities[attributeIds[0]];
-    }
-
-    /// @dev This logic is derived from Pokemon
-    function _calcNecessaryExp(CharacterInfo memory charInfo)
-        internal
-        pure
-        returns (uint256)
-    {
-        return uint256(charInfo.level)**2;
     }
 }

--- a/src/subcontracts/PLMData.sol
+++ b/src/subcontracts/PLMData.sol
@@ -39,7 +39,7 @@ contract PLMData is IPLMData {
     }
 
     function _rate(uint8 x) internal view returns (bool) {
-        return uint256(PLMSeeder.generateRandomSlotNonce()) % 100 < x;
+        return uint256(PLMSeeder.randomFromBlockHash()) % 100 < x;
     }
 
     function _characterTypes() internal view returns (string[] memory) {

--- a/src/subcontracts/PLMGacha.sol
+++ b/src/subcontracts/PLMGacha.sol
@@ -26,22 +26,14 @@ contract PLMGacha is IPLMGacha, ReentrancyGuard {
     ///         2. mint PLMToken by this contract
     ///         2. transfer minted token from this contract to the sender
     function gacha(bytes32 name) external nonReentrant {
-        try token.mint(name) returns (uint256 tokenId) {
-            try coin.transferFrom(msg.sender, address(this), GACHA_FEE) {
-                token.transferFrom(address(this), msg.sender, tokenId);
-                emit CharacterReceivedByUser(
-                    msg.sender,
-                    tokenId,
-                    token.getCurrentCharacterInfo(tokenId)
-                );
-            } catch Error(string memory reason) {
-                // token.burn(tokenId);
-                // TODO:emit gacha payment failed
-                revert ErrorWithLog(reason);
-            }
-        } catch Error(string memory reason) {
-            revert ErrorWithLog(reason);
-        }
+        coin.transferFrom(msg.sender, address(this), GACHA_FEE);
+        uint256 tokenId = token.mint(name);
+        token.transferFrom(address(this), msg.sender, tokenId);
+        emit CharacterReceivedByUser(
+            msg.sender,
+            tokenId,
+            token.getCurrentCharacterInfo(tokenId)
+        );
     }
 
     ////////////////////////

--- a/src/subcontracts/PLMGacha.sol
+++ b/src/subcontracts/PLMGacha.sol
@@ -26,14 +26,6 @@ contract PLMGacha is IPLMGacha, ReentrancyGuard {
     ///         2. mint PLMToken by this contract
     ///         2. transfer minted token from this contract to the sender
     function gacha(bytes32 name) external nonReentrant {
-        require(
-            coin.allowance(msg.sender, address(this)) >= GACHA_FEE,
-            "coin allowance insufficient /gacha"
-        );
-        require(
-            coin.balanceOf(msg.sender) >= GACHA_FEE,
-            "not sufficient balance /gacha"
-        );
         try token.mint(name) returns (uint256 tokenId) {
             try coin.transferFrom(msg.sender, address(this), GACHA_FEE) {
                 token.transferFrom(address(this), msg.sender, tokenId);

--- a/test/PLMSeeder.t.sol
+++ b/test/PLMSeeder.t.sol
@@ -105,7 +105,7 @@ contract PLMSeederTest is Test {
             tokenId++;
             currentBlock++;
             vm.roll(currentBlock);
-            PLMSeeder.Seed memory seed = PLMSeeder.generateSeed(
+            PLMSeeder.Seed memory seed = PLMSeeder.generateTokenSeed(
                 tokenId,
                 IPLMData(address(tokenContract))
             );

--- a/test/PLMSeeder.t.sol
+++ b/test/PLMSeeder.t.sol
@@ -112,13 +112,13 @@ contract PLMSeederTest is Test {
             string[] memory characterTypes = IPLMData(address(tokenContract))
                 .getCharacterTypes();
             IPLMData.CharacterInfo memory minted = IPLMData.CharacterInfo(
-                "a",
+                1,
+                1,
                 1,
                 block.number,
-                characterTypes[seed.characterType],
-                1,
-                1,
-                [seed.attribute]
+                [seed.attribute],
+                "a",
+                characterTypes[seed.characterType]
             );
             generatedAttributes[i] = minted.attributeIds[0];
             // generatedAbility[i] = minted.abilityIds[0];


### PR DESCRIPTION
チェック項目
- public をexternal, internalに分割
- improve 関数名、変数名
- 繰り返される処理は関数化
- require 文
   - the, period, !=, 短かったらbe verb.は削除 (可読性注意)
   - 不要な複数requireは削除
   - 同じ意味の文章は make consistent
- 同じcontract内の変数は極力直接よぶ。
- 一度しか呼ばれない一次変数は削除（可読性は意識） 

変更箇所
- Seeder
   - 関数名を適切なものに変更。
- Data
   - 関数の順番を整理
- Gacha (2.404 kB => 1.716 kB)
   - 不要なtry-catch, requireを削除    
- Coin (2.837 kB => 2.727 kB)
   - 不要な記述を削除
     - IsSet系
- Dealer (7.543 kB => 6.33 kB)
   - 関数の順番がルール通りでなかったところを変更 
   - 不要な記述を削除
     - isSet系
     - require 文： the, period, !=, 短かったらbe verb.は削除
     - transferする際の残高を確認するrequire (ERC20側でrequireがあるため不要) 
- Token (23.344 kB => 22.19 kB)
  - require の is not => != 
  - CharacterInfo のメンバの順番を小さいサイズにパックされるように入れ替え
  - searchHogeCheckpointsがCharInfo, TotalSupplyそれぞれあったものを、EnumでcheckPointsの種類を管理するように変更して統合。
  - 不要な記述を削除
     - isSet系
     -  require 文： the, period, !=, 短かったらbe verb.は削除

- リファクタ前
![image](https://user-images.githubusercontent.com/49639555/204065905-32cd83e2-4064-4d95-8318-df77d67e6b6c.png)
- リファクタ後
<img width="333" alt="image" src="https://user-images.githubusercontent.com/49639555/204065897-65578df1-d863-458e-b335-7aceee5cc108.png">
