### PR TITLE
MOD: refactor/checkpoint_searching

### DIFF
--- a/src/lib/Utils.sol
+++ b/src/lib/Utils.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+
+library Utils {
+    function getPrior(
+        uint256 targetValue,
+        address callAddress,
+        string memory numFunc,
+        string memory elementFunc,
+        uint256[] memory numArgs,
+        uint256[] memory elementArgs
+    ) external view returns (uint32 index, bool found) {
+        bytes4 numFuncSig = bytes4((keccak256(abi.encodePacked(numFunc))));
+        bytes memory numFuncPacked = curryUint(numFuncSig, numArgs);
+        bytes4 elementFuncSig = bytes4(
+            (keccak256(abi.encodePacked(elementFunc)))
+        );
+        bytes memory elementFuncPacked = curryUint(elementFuncSig, elementArgs);
+        return
+            binarySearchIdx(
+                numFuncPacked,
+                elementFuncPacked,
+                targetValue,
+                callAddress
+            );
+    }
+
+    /// @notice Run binary search in a type of checkpoints.
+    /// @dev this function can be used for any checkpoints types.
+    function binarySearchIdx(
+        bytes memory lengthFuncPacked,
+        bytes memory elementFuncPacked,
+        uint256 targetValue,
+        address funcAddress
+    ) public view returns (uint32, bool) {
+        console.log(msg.sender);
+        uint32 numElements = _callGetLength(lengthFuncPacked, funcAddress);
+
+        if (numElements == 0) {
+            return (0, false);
+        }
+
+        // First check the most recent
+        if (
+            _callGetElementByIdx(
+                elementFuncPacked,
+                numElements - 1,
+                funcAddress
+            ) <= targetValue
+        ) {
+            return (numElements - 1, true);
+        }
+
+        // Nest check implicit zero
+        if (
+            _callGetElementByIdx(elementFuncPacked, 0, funcAddress) >
+            targetValue
+        ) {
+            return (0, false);
+        }
+
+        /// @notice calc the array index where the targetValue that you want to search is placed by binary search
+        uint32 lower = 0;
+        uint32 upper = numElements - 1;
+        while (upper > lower) {
+            uint32 center = upper - (upper - lower) / 2; // ceil, avoiding overflow
+            uint256 element = _callGetElementByIdx(
+                elementFuncPacked,
+                center,
+                funcAddress
+            );
+
+            if (element == targetValue) {
+                return (center, true);
+            } else if (element < targetValue) {
+                lower = center;
+            } else {
+                upper = center - 1;
+            }
+        }
+        return (lower, true);
+    }
+
+    function _callGetLength(bytes memory lengthFuncPacked, address caller)
+        internal
+        view
+        returns (uint32)
+    {
+        (bool success, bytes memory result) = caller.staticcall(
+            lengthFuncPacked
+        );
+        if (success) {
+            return abi.decode(result, (uint32));
+        } else {
+            revert("call failed: getLength");
+        }
+    }
+
+    function _callGetElementByIdx(
+        bytes memory elementFuncPacked,
+        uint32 index,
+        address caller
+    ) internal view returns (uint256) {
+        (bool success, bytes memory result) = caller.staticcall(
+            abi.encodePacked(elementFuncPacked, uint256(index))
+        );
+        if (success) {
+            return abi.decode(result, (uint256));
+        } else {
+            revert("call failed: get Element");
+        }
+    }
+
+    /// @dev curry of uint256s
+    function curryUint(bytes4 funcSig, uint256[] memory args)
+        public
+        pure
+        returns (bytes memory)
+    {
+        bytes memory packed;
+        for (uint256 i = 0; i < args.length; i++) {
+            if (i == 0) {
+                packed = abi.encodePacked(args[i]);
+            } else {
+                packed = abi.encodePacked(packed, args[i]);
+            }
+        }
+        return abi.encodePacked(funcSig, packed);
+    }
+}

--- a/test/Utils.t.sol
+++ b/test/Utils.t.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import "../src/lib/Utils.sol";
+
+contract UtilsTest is Test {
+    function setUp() public {}
+
+    /// @dev example of a function whose all args are uints whose byte size are defferent
+    function sum(uint8 a, uint16 b) public pure returns (uint32) {
+        return a + b;
+    }
+
+    function echo(uint32 a) public pure returns (uint256) {
+        return a;
+    }
+
+    function testCurry() public {
+        uint256[] memory args = new uint256[](2);
+        uint8 args0 = 2;
+        uint16 args1 = 1;
+        args[0] = args0;
+        args[1] = args1;
+
+        bytes4 funcSig = bytes4(keccak256("sum(uint8,uint16)"));
+
+        assertEq(
+            abi.encodeWithSelector(funcSig, args0, args1),
+            Utils.curryUint(funcSig, args)
+        );
+    }
+
+    /////////////////////////////
+    // preparing indexed array //
+    /////////////////////////////
+    uint256[] searcheeArray = [
+        2,
+        3,
+        9,
+        12,
+        18,
+        21,
+        22,
+        24,
+        29,
+        35,
+        38,
+        39,
+        41,
+        42,
+        46,
+        49,
+        52
+    ];
+
+    /// @dev for bin search test
+    function getLength() public view returns (uint256) {
+        return searcheeArray.length;
+    }
+
+    /// @dev for bin search test
+    function getElementByIdx(uint32 index) public view returns (uint256) {
+        return searcheeArray[index];
+    }
+
+    /// @dev test of binarySearchIdx
+    function testBinarySearchIdx() public {
+        uint256 targetValue = 34;
+
+        bytes memory getLengthPacked = abi.encodePacked(
+            bytes4(keccak256("getLength()"))
+        );
+        bytes memory getElementPacked = abi.encodePacked(
+            bytes4(keccak256("getElementByIdx(uint32)"))
+        );
+        (uint32 i1, bool result1) = Utils.binarySearchIdx(
+            getLengthPacked,
+            getElementPacked,
+            targetValue,
+            address(this)
+        );
+        assertEq(i1, 8, "searching failed");
+        assertEq(result1, true);
+
+        targetValue = 1;
+        (uint32 i2, bool result2) = Utils.binarySearchIdx(
+            getLengthPacked,
+            getElementPacked,
+            targetValue,
+            address(this)
+        );
+        assertEq(i2, 0, "searching failed");
+        assertEq(result2, false, "target is lower than index 0");
+    }
+
+    /// @dev test of getPrior function
+    function testGetPriorUtils() public {
+        uint256 targetValue = 34;
+
+        uint256[] memory numArgs;
+        uint256[] memory elementArgs;
+
+        (uint32 i1, bool result1) = Utils.getPrior(
+            targetValue,
+            address(this),
+            "getLength()",
+            "getElementByIdx(uint32)",
+            numArgs,
+            elementArgs
+        );
+        assertEq(i1, 8, "searching failed");
+        assertEq(result1, true);
+    }
+}


### PR DESCRIPTION
## やったこと
- utils library
  - curryUint実装
  - binarySearchIdx関数を実装してcheckpointの探索を抽象化
    - 外からの見え方は変わっていません。
  - utilsに実装した、curryUint, binarySearchIdx, getPriorUtilsは全てunitTestをtest/Utils.t.solに書いて、pass済み
  - 既存のtestにも全てpass済み。
## 留意事項  
-  call() 系ではexternal, publicの関数しか呼べないため, checkPointの探索でcallで呼び出して使用する_numHogeCheckPoints, _hogeCheckPointFromBlock系を一時的にpublicにしています。（名前はそのまま）
- 