### PR TITLE
Fix/deploy testnet

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-GOERLI_RPC_URL="https://rpc-mumbai.maticvigil.com/"
+GOERLI_RPC_URL="https://polygon-mumbai.g.alchemy.com/v2/PSCsM6pbhS6upX-Wisc6Ny442d-eqC4V"
 ETHERSCAN_API_KEY="ADS67TY9YE4GYQT8UYPMAV6GPQ1M45JMRR"

--- a/json/contract_address_list.json
+++ b/json/contract_address_list.json
@@ -1,0 +1,44 @@
+{
+    "contracts": [
+        {
+            "contractName": "PLMSeeder",
+            "contractAddress": "0xD3395Ece9cBA08D2Abe5A22Fdcf2bE0144fAA738"
+        },
+        {
+            "contractName": "Utils",
+            "contractAddress": "0xe69c1eE0BE396E221eABB0b86027f046F815f726"
+        },
+        {
+            "contractName": "PLMCoin",
+            "contractAddress": "0xF9e6181C9D26cDFa801cbbfaDD2D8e59daec0CcD"
+        },
+        {
+            "contractName": "PLMLevelsV1",
+            "contractAddress": "0x6fb529eE3D6C6Ad122021A002F3609f8670674f9"
+        },
+        {
+            "contractName": "PLMTypesV1",
+            "contractAddress": "0xBEe712d0024FF196749B6DcE6E6C3Fed6E079290"
+        },
+        {
+            "contractName": "PLMData",
+            "contractAddress": "0xBB3491c528f987e2847A715F7372A7AC25c2ee43"
+        },
+        {
+            "contractName": "PLMToken",
+            "contractAddress": "0x10a5eEeB157F2232d350CbDc88E45509eD71F818"
+        },
+        {
+            "contractName": "PLMDealer",
+            "contractAddress": "0xDf95eEBBBB566B5144e4cFD58765E9099C06C232"
+        },
+        {
+            "contractName": "PLMMatchOrganizer",
+            "contractAddress": "0x70D389aC09F88fEaB31C3C2B0a6cfdFE90741C53"
+        },
+        {
+            "contractName": "PLMBattleField",
+            "contractAddress": "0x1216671Ad3Ff1e86a2e41cd97149A79eF911568a"
+        }
+    ]
+}


### PR DESCRIPTION
## issue
foundry の forge script コマンドを使ってtestnetへデプロイする際、Upgrade to an archive plan add-on for your account. Max height of block allowed on archive for your current plan: と出てデプロイが失敗する
[notion該当箇所](https://www.notion.so/standard2017cojp/ae92f3b811f242cf906137f6ee7e82c6#0463475a978e42ee84d9b3e3cf22bb2c)

## 修正 追加実装内容
- rpc url (testnet provider) を archiaval node 機能がある Alchemy の ものに変更した (.env ファイルが書き換えられています)
- mumbai testnetにデプロイ済み
   - json/contract_address_list.json にデプロイした結果のコントラクトアドレスを記載済み
 
## 備考
@hashi0203  testnetにトランザクションを投げる前に、使用するmetamaskのwalletの設定で rpc-urlを変更してください。（.envファイルにあるURLに変更）
