### PR TITLE
Feature/multislot battle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/openzeppelin/openzeppelin-contracts
+[submodule "lib/sstore2"]
+	path = lib/sstore2
+	url = https://github.com/0xsequence/sstore2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
     ],
     "solidity.formatter": "prettier",
     "solidity.linter": "solium",
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "solidity.validationDelay": 5
 }

--- a/script/Polylemma.s.sol
+++ b/script/Polylemma.s.sol
@@ -9,6 +9,8 @@ import {PLMData} from "src/PLMData.sol";
 import {PLMDealer} from "src/PLMDealer.sol";
 import {PLMMatchOrganizer} from "src/PLMMatchOrganizer.sol";
 import {PLMBattleField} from "src/PLMBattleField.sol";
+import {PLMBattleManager} from "../src/PLMBattleManager.sol";
+import {PLMBattleStorage} from "../src/PLMBattleStorage.sol";
 import {PLMTypesV1} from "src/data-contracts/PLMTypesV1.sol";
 import {PLMLevelsV1} from "src/data-contracts/PLMLevelsV1.sol";
 
@@ -16,6 +18,8 @@ import {IPLMToken} from "../src/interfaces/IPLMToken.sol";
 import {IPLMCoin} from "../src/interfaces/IPLMCoin.sol";
 import {IPLMData} from "../src/interfaces/IPLMData.sol";
 import {IPLMDealer} from "../src/interfaces/IPLMDealer.sol";
+import {IPLMBattleManager} from "../src/interfaces/IPLMBattleManager.sol";
+import {IPLMBattleStorage} from "../src/interfaces/IPLMBattleStorage.sol";
 import {IPLMBattleField} from "src/interfaces/IPLMBattleField.sol";
 import {IPLMMatchOrganizer} from "src/interfaces/IPLMMatchOrganizer.sol";
 import {IPLMTypes} from "src/interfaces/IPLMTypes.sol";
@@ -30,7 +34,11 @@ contract PolylemmaScript is Script {
     PLMBattleField battleField;
     PLMTypesV1 typesContract;
     PLMLevelsV1 levelsContract;
+    IPLMBattleStorage strg;
+    IPLMBattleManager manager;
 
+    PLMBattleStorage strgContract;
+    PLMBattleManager managerContract;
     IPLMToken token;
     IPLMCoin coin;
     IPLMDealer dealer;
@@ -65,14 +73,19 @@ contract PolylemmaScript is Script {
         tokenContract = new PLMToken(coin, data, tokenMaxSupply);
         token = IPLMToken(address(tokenContract));
 
+        strgContract = new PLMBattleStorage();
+        strg = IPLMBattleStorage(address(strgContract));
+        managerContract = new PLMBattleManager(strg);
+        manager = IPLMBattleManager(address(managerContract));
         dealer = new PLMDealer(token, coin);
         matchOrganizer = new PLMMatchOrganizer(dealer, token);
-        battleField = new PLMBattleField(dealer, token);
+        battleField = new PLMBattleField(dealer, token, manager);
 
         coin.setDealer(address(dealer));
         token.setDealer(address(dealer));
         dealer.setMatchOrganizer(address(matchOrganizer));
         dealer.setBattleField(address(battleField));
+        strg.setBattleManager(address(managerContract));
 
         matchOrganizer.setPLMBattleField(address(battleField));
         battleField.setPLMMatchOrganizer(address(matchOrganizer));

--- a/src/PLMBattleField.sol
+++ b/src/PLMBattleField.sol
@@ -4,16 +4,20 @@ pragma experimental ABIEncoderV2;
 
 import {PLMSeeder} from "./lib/PLMSeeder.sol";
 
-import {ReentrancyGuard} from "openzeppelin-contracts/security/ReentrancyGuard.sol";
-
 import {IPLMToken} from "./interfaces/IPLMToken.sol";
 import {IPLMDealer} from "./interfaces/IPLMDealer.sol";
 import {IPLMData} from "./interfaces/IPLMData.sol";
 import {IPLMBattleField} from "./interfaces/IPLMBattleField.sol";
 import {IPLMMatchOrganizer} from "./interfaces/IPLMMatchOrganizer.sol";
+import {IPLMBattleManager} from "./interfaces/IPLMBattleManager.sol";
 import {IERC165} from "openzeppelin-contracts/utils/introspection/IERC165.sol";
 
-contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
+contract PLMBattleField is IPLMBattleField, IERC165 {
+    /// @notice for reentrancyGuard;
+    /// @dev this constant is implemented as uint256 because it is inplemented in this manner in Openzeppelin
+    uint256 private constant _NOT_ENTERED = 1;
+    uint256 private constant _ENTERED = 2;
+
     /// @notice The number of the maximum round.
     uint8 constant MAX_ROUNDS = 5;
 
@@ -53,66 +57,43 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
     /// @notice interface to the MatchOrganizer.
     IPLMMatchOrganizer matchOrganizer;
 
+    /// @notice interface to the battleManager.
+    IPLMBattleManager manager;
+
     /// @notice admin's address
     address polylemmers;
 
-    /// @notice number of rounds. When on 1st round, numRounds==0 (< MAX_ROUNDS)
-    uint8 numRounds;
+    /// @notice latest battle ID
+    mapping(address => uint256) battleId;
 
-    /// @notice state of the battle.
-    BattleState battleState;
+    /// @notice latest enemy address
+    mapping(address => address) enemyAddr;
 
-    // FIXME: It may be better to hold this information by mapping ... ??
-    /// @notice array of the information on the winner and loser of each round
-    RoundResult[MAX_ROUNDS] roundResults;
+    /// @notice status for reentrancy guard for each battle, battle Id => locked flag, _NOT_ENTERED or _ENTERED
+    mapping(uint256 => uint256) private _status;
 
-    /// @notice cache of the battle Result
-    BattleResult battleResult;
-
-    /// @notice block number when playerSeed commitment starts.
-    uint256 playerSeedCommitFromBlock;
-
-    // FIXME: It may be better to write uint256[MAX_ROUNDS] ... ??
-    /// @notice block number log when choice committment starts for all rounds.
-    mapping(uint8 => uint256) choiceCommitFromBlocks;
-
-    // FIXME: It may be better to write uint256[MAX_ROUNDS] ... ??
-    /// @notice block number log when choice revealment starts for all rounds.
-    mapping(uint8 => uint256) choiceRevealFromBlocks;
-
-    // FIXME: It may be better to write ChoiceCommit[2 * MAX_ROUNDS] ... ??
-    /// @notice commitment log for all rounds.
-    /// @dev The key is numRounds.
-    mapping(uint8 => mapping(PlayerId => ChoiceCommit)) choiceCommitLog;
-
-    // FIXME: PlayerSeedCommit[2] may be better ... ??
-    /// @notice commitment log for player seed for random slot generation.
-    mapping(PlayerId => PlayerSeedCommit) playerSeedCommitLog;
-
-    /// @notice players' information
-    mapping(PlayerId => PlayerInfo) playerInfoTable;
-
-    constructor(IPLMDealer _dealer, IPLMToken _token) {
+    constructor(
+        IPLMDealer _dealer,
+        IPLMToken _token,
+        IPLMBattleManager _manager
+    ) {
         dealer = _dealer;
         token = _token;
+        manager = _manager;
         data = IPLMData(_token.getDataAddr());
         polylemmers = msg.sender;
     }
 
-    /// @notice Check whether the caller of the function is the valid account.
-    /// @param playerId: The player's identifier.
-    modifier onlyPlayerOf(PlayerId playerId) {
-        require(
-            msg.sender == _playerAddr(playerId),
-            "caller != player of playerId"
-        );
+    modifier nonReentrantForEachBattle() {
+        _nonReentrantForEachBattleBefore();
         _;
+        _nonReentrantForEachBattleAfter();
     }
 
     /// @notice Check that the battle state is standby.
     modifier standby() {
         require(
-            battleState == BattleState.Standby,
+            _battleState() == BattleState.Standby,
             "Battle state isn't standby yet"
         );
         _;
@@ -121,8 +102,21 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
     /// @notice Check that the battle round has already started.
     modifier inRound() {
         require(
-            battleState == BattleState.InRound,
+            _battleState() == BattleState.InRound,
             "Battle round hasn't started yet"
+        );
+        _;
+    }
+
+    modifier onlyPlayerOf() {
+        uint256 _battleId = battleId[msg.sender];
+        BattleState battleState = manager.getBattleStateById(_battleId);
+        require(
+            _battleId == battleId[enemyAddr[msg.sender]] &&
+                (battleState != BattleState.NotStarted ||
+                    battleState != BattleState.Settled ||
+                    battleState != BattleState.Canceled),
+            "call invalid battle"
         );
         _;
     }
@@ -139,43 +133,48 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
         _;
     }
 
-    /// @notice Check that the random slot of the player designated by playerId
+    /// @notice Check that the random slot of the player designated by player
     ///         has already been committed, the choice of that player in this
     ///         round is randomSlot, and it has already been revealed.
-    modifier readyForPlayerSeedReveal(PlayerId playerId) {
+    modifier readyForPlayerSeedReveal() {
         // Prevent double revealing.
         require(
-            _randomSlotState(playerId) == RandomSlotState.Committed,
+            _randomSlotState(msg.sender) == RandomSlotState.Committed,
             "playerSeed has already been revealed."
         );
 
+        address _enemyAddr = enemyAddr[msg.sender];
         require(
-            _playerState(playerId) == PlayerState.Committed &&
-                (_playerState(_enemyId(playerId)) == PlayerState.Committed ||
-                    _playerState(_enemyId(playerId)) == PlayerState.Revealed),
+            _playerState(msg.sender) == PlayerState.Committed &&
+                (_playerState(_enemyAddr) == PlayerState.Committed ||
+                    _playerState(_enemyAddr) == PlayerState.Revealed),
             "Home or Visitor hasn't committed one's choice yet"
         );
         _;
     }
 
     /// @notice Check that both players have already committed in this round.
-    /// @param playerId: The player's identifier.
-    modifier readyForChoiceReveal(PlayerId playerId) {
+    modifier readyForChoiceReveal() {
         require(
-            _playerState(playerId) == PlayerState.Committed,
+            _playerState(msg.sender) == PlayerState.Committed,
             "Player hasn't committed the choice yet"
         );
 
-        PlayerState enemyState = _playerState(_enemyId(playerId));
+        address _enemyAddr = enemyAddr[msg.sender];
+        PlayerState enemyState = _playerState(_enemyAddr);
 
         // If the enemy player has not committed yet and it's over commit time limit,
         // ban the enemy player as delayer.
         if (enemyState == PlayerState.Standby && _isLateForChoiceCommit()) {
-            emit LateChoiceCommitDetected(numRounds, _enemyId(playerId));
+            emit LateChoiceCommitDetected(
+                battleId[msg.sender],
+                manager.getNumRounds(msg.sender),
+                _enemyAddr
+            );
 
-            // Deal with the delayer (the player designated by playerId) and cancel
+            // Deal with the delayer (the player designated by player) and cancel
             // this battle.
-            _dealWithDelayerAndCancelBattle(playerId);
+            _dealWithDelayerAndCancelBattle(msg.sender);
             return;
         }
 
@@ -190,16 +189,48 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
         _;
     }
 
-    /// @notice Check that this battle is ready for start.
-    modifier readyForBattleStart() {
-        // TODO: modify here when we extend battle field to multi slots.
+    function _nonReentrantForEachBattleBefore() private {
+        uint256 _battleId = battleId[msg.sender];
+
+        // On the first call to nonReentrantForEachBattle, _status will be _NOT_ENTERED
         require(
-            battleState == BattleState.NotStarted ||
-                battleState == BattleState.Settled ||
-                battleState == BattleState.Canceled,
-            "Battle isn't ready for start."
+            _status[_battleId] != _ENTERED,
+            "ReentrancyGuard: reentrant call"
         );
-        _;
+
+        // Any calls to nonReentrantForEachBattle after this point will fail
+        _status[_battleId] = _ENTERED;
+    }
+
+    function _nonReentrantForEachBattleAfter() private {
+        // By storing the original value once again, a refund is triggered (see
+        // https://eips.ethereum.org/EIPS/eip-2200)
+        _status[battleId[msg.sender]] = _NOT_ENTERED;
+    }
+
+    /// @notice Function to execute closing round.
+    /// @dev This function is automatically called in the end of _stepRound
+    function _endRound(
+        uint32 winnerDamage,
+        uint32 loserDamage,
+        address winner,
+        bool isDraw
+    ) internal {
+        address _enemyAddr = enemyAddr[winner];
+        manager.incrementPlayerInfoWinCount(winner);
+        manager.setRoundResult(
+            msg.sender,
+            RoundResult(isDraw, winner, _enemyAddr, winnerDamage, loserDamage)
+        );
+        emit RoundCompleted(
+            battleId[msg.sender],
+            manager.getNumRounds(msg.sender),
+            isDraw,
+            winner,
+            _enemyAddr,
+            winnerDamage,
+            loserDamage
+        );
     }
 
     /// @notice Function to execute the current round.
@@ -207,129 +238,96 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
     ///      of this round.
     function _stepRound() internal {
         // Mark the slot as used.
-        _markSlot(PlayerId.Home);
-        _markSlot(PlayerId.Visitor);
+        _markSlot(msg.sender);
+        address _enemyAddr = enemyAddr[msg.sender];
+        _markSlot(_enemyAddr);
 
         // Calculate the damage of both players.
         // Minimalize character info
-        IPLMData.CharacterInfoMinimal memory homeChar = _chosenCharacterInfo(
-            PlayerId.Home
+        IPLMData.CharacterInfoMinimal memory myChar = _chosenCharacterInfo(
+            msg.sender
         );
-        IPLMData.CharacterInfoMinimal memory visitorChar = _chosenCharacterInfo(
-            PlayerId.Visitor
-        );
-
-        uint32 homeDamage = data.getDamage(
-            numRounds,
-            homeChar,
-            choiceCommitLog[numRounds][PlayerId.Home].levelPoint,
-            _bondLevelAtBattleStart(homeChar.level, homeChar.fromBlock),
-            visitorChar
+        IPLMData.CharacterInfoMinimal memory enemyChar = _chosenCharacterInfo(
+            _enemyAddr
         );
 
-        uint32 visitorDamage = data.getDamage(
-            numRounds,
-            visitorChar,
-            choiceCommitLog[numRounds][PlayerId.Visitor].levelPoint,
-            _bondLevelAtBattleStart(visitorChar.level, visitorChar.fromBlock),
-            homeChar
-        );
+        uint8 numRounds = manager.getNumRounds(msg.sender);
 
-        // Judge the battle result of this round.
-        if (homeDamage > visitorDamage) {
-            // home wins !!
-            playerInfoTable[PlayerId.Home].winCount++;
-
-            roundResults[numRounds] = RoundResult(
-                false,
-                PlayerId.Home,
-                PlayerId.Visitor,
-                homeDamage,
-                visitorDamage
-            );
-            emit RoundCompleted(
+        /// @notice this {} to avoid stacking to deep error
+        {
+            uint32 myDamage = data.getDamage(
                 numRounds,
-                false,
-                PlayerId.Home,
-                PlayerId.Visitor,
-                homeDamage,
-                visitorDamage
+                myChar,
+                manager.getChoiceCommitLevelPoint(msg.sender),
+                _bondLevelAtBattleStart(myChar.level, myChar.fromBlock),
+                enemyChar
             );
-        } else if (homeDamage < visitorDamage) {
-            // visitor wins !!
-            playerInfoTable[PlayerId.Visitor].winCount++;
-            roundResults[numRounds] = RoundResult(
-                false,
-                PlayerId.Visitor,
-                PlayerId.Home,
-                visitorDamage,
-                homeDamage
-            );
-            emit RoundCompleted(
+
+            uint32 enemyDamage = data.getDamage(
                 numRounds,
-                false,
-                PlayerId.Visitor,
-                PlayerId.Home,
-                visitorDamage,
-                homeDamage
+                enemyChar,
+                manager.getChoiceCommitLevelPoint(_enemyAddr),
+                _bondLevelAtBattleStart(enemyChar.level, enemyChar.fromBlock),
+                myChar
             );
-        } else {
-            // Draw !!
-            roundResults[numRounds] = RoundResult(
-                true,
-                PlayerId.Home,
-                PlayerId.Visitor,
-                homeDamage,
-                visitorDamage
-            );
-            emit RoundCompleted(
-                numRounds,
-                true,
-                PlayerId.Home,
-                PlayerId.Visitor,
-                homeDamage,
-                visitorDamage
-            );
+
+            // Judge the battle result of this round.
+            if (myDamage > enemyDamage) {
+                // home wins !!
+                _endRound(myDamage, enemyDamage, msg.sender, false);
+            } else if (myDamage < enemyDamage) {
+                // visitor wins !!
+                _endRound(enemyDamage, myDamage, _enemyAddr, false);
+            } else {
+                // Draw !!
+                _endRound(myDamage, enemyDamage, msg.sender, true);
+            }
         }
 
         // Increment the round number.
+        manager.incrementNumRounds(msg.sender);
         numRounds++;
-        uint8 homeWinCount = _winCount(PlayerId.Home);
-        uint8 visitorWinCount = _winCount(PlayerId.Visitor);
 
-        uint8 diffWinCount = homeWinCount > visitorWinCount
-            ? homeWinCount - visitorWinCount
-            : visitorWinCount - homeWinCount;
+        uint8 myWinCount = _winCount(msg.sender);
+        uint8 enemyWinCount = _winCount(_enemyAddr);
+
+        uint8 diffWinCount = myWinCount > enemyWinCount
+            ? myWinCount - enemyWinCount
+            : enemyWinCount - myWinCount;
 
         // Check whether the battle round continues or not.
         if (
             numRounds == MAX_ROUNDS || diffWinCount > (MAX_ROUNDS - numRounds)
         ) {
-            battleState = BattleState.RoundSettled;
+            manager.setBattleState(msg.sender, BattleState.RoundSettled);
 
             // Check draw condition.
-            bool isDraw = homeWinCount == visitorWinCount;
+            bool isDraw = myWinCount == enemyWinCount;
 
-            PlayerId winner = homeWinCount >= visitorWinCount
-                ? PlayerId.Home
-                : PlayerId.Visitor;
-            PlayerId loser = _enemyId(winner);
+            address winner = myWinCount >= enemyWinCount
+                ? msg.sender
+                : _enemyAddr;
+            address loser = _enemyAddr;
             uint8 winnerCount = _winCount(winner);
             uint8 loserCount = _winCount(loser);
 
-            battleResult = BattleResult(
-                numRounds - 1,
-                isDraw,
-                winner,
-                loser,
-                winnerCount,
-                loserCount
+            manager.setBattleResult(
+                msg.sender,
+                BattleResult(
+                    numRounds - 1,
+                    isDraw,
+                    winner,
+                    loser,
+                    winnerCount,
+                    loserCount
+                )
             );
 
             // This battle ends.
             _settleBattle();
 
             emit BattleCompleted(
+                battleId[msg.sender],
                 numRounds - 1,
                 isDraw,
                 winner,
@@ -341,11 +339,11 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
         }
 
         // Reset the player states.
-        playerInfoTable[PlayerId.Home].state = PlayerState.Standby;
-        playerInfoTable[PlayerId.Visitor].state = PlayerState.Standby;
+        manager.setPlayerInfoState(msg.sender, PlayerState.Standby);
+        manager.setPlayerInfoState(_enemyAddr, PlayerState.Standby);
 
         // Set the block number when the next round starts.
-        choiceCommitFromBlocks[numRounds] = block.number;
+        manager.setCommitFromBlock(msg.sender, block.number);
     }
 
     /// @notice Function to deal with cheater and cancel battle.
@@ -353,15 +351,15 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
     ///         subscribing period limit.)
     ///      2. Refund stamina for the enemy honest player.
     ///      3. Cancel this battle.
-    function _dealWithCheaterAndCancelBattle(PlayerId playerId) internal {
+    function _dealWithCheaterAndCancelBattle(address player) internal {
         // Reduce the subscribing period to ban the cheater account.
         dealer.banAccount(
-            _playerAddr(playerId),
+            player,
             DAILY_BLOCK_NUM * BAN_DATE_LENGTH_FOR_CHEATER
         );
 
         // Refund stamina for the enemy player.
-        dealer.refundStaminaForBattle(_playerAddr(_enemyId(playerId)));
+        dealer.refundStaminaForBattle(enemyAddr[msg.sender]);
 
         // Cancel battle because of cheat detection.
         _cancelBattle();
@@ -372,15 +370,15 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
     ///         subscribing period limit.)
     ///      2. Refund stamina for the enemy honest player.
     ///      3. Cancel this battle.
-    function _dealWithDelayerAndCancelBattle(PlayerId playerId) internal {
+    function _dealWithDelayerAndCancelBattle(address player) internal {
         // Reduce the subscribing period to ban the delayer's account.
         dealer.banAccount(
-            _playerAddr(playerId),
+            player,
             DAILY_BLOCK_NUM * BAN_DATE_LENGTH_FOR_DELAYER_ACCOUNT
         );
 
         // Refund stamina for the enemy player.
-        dealer.refundStaminaForBattle(_playerAddr(_enemyId(playerId)));
+        dealer.refundStaminaForBattle(enemyAddr[msg.sender]);
 
         // Cancel battle because of delay detection.
         _cancelBattle();
@@ -393,11 +391,11 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
     function _dealWithDelayersAndCancelBattle() internal {
         // Reduce the subscribing period to ban both players' accounts.
         dealer.banAccount(
-            _playerAddr(PlayerId.Home),
+            msg.sender,
             DAILY_BLOCK_NUM * BAN_DATE_LENGTH_FOR_DELAYER_ACCOUNT
         );
         dealer.banAccount(
-            _playerAddr(PlayerId.Visitor),
+            enemyAddr[msg.sender],
             DAILY_BLOCK_NUM * BAN_DATE_LENGTH_FOR_DELAYER_ACCOUNT
         );
 
@@ -407,39 +405,33 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
 
     /// @notice Core logic to finalization of the battle.
     function _settleBattle() internal {
-        if (battleResult.isDraw) {
+        BattleResult memory br = manager.getBattleResult(msg.sender);
+        if (br.isDraw) {
             // this battle is draw. pay rewards to both of players from dealer.
             _payRewardsDraw();
         } else {
             // Pay rewards (PLMCoin) to the winner from dealer.
-            _payRewards(battleResult.winner, battleResult.loser);
+            _payRewards(br.winner, br.loser);
         }
 
         // Update the proposal state.
-        matchOrganizer.resetMatchStates(
-            playerInfoTable[PlayerId.Home].addr,
-            playerInfoTable[PlayerId.Visitor].addr
-        );
+        matchOrganizer.resetMatchStates(msg.sender, enemyAddr[msg.sender]);
 
         // settle this battle.
-        battleState = BattleState.Settled;
+        manager.setBattleState(msg.sender, BattleState.Settled);
     }
 
     /// @notice Function to cancel this battle.
     function _cancelBattle() internal {
-        // TODO: modify here when we implement multislot battle.
-        matchOrganizer.resetMatchStates(
-            playerInfoTable[PlayerId.Home].addr,
-            playerInfoTable[PlayerId.Visitor].addr
-        );
-        battleState = BattleState.Canceled;
+        matchOrganizer.resetMatchStates(msg.sender, enemyAddr[msg.sender]);
+        manager.setBattleState(msg.sender, BattleState.Canceled);
 
-        emit BattleCanceled();
+        emit BattleCanceled(battleId[msg.sender]);
     }
 
     /// @notice Function to pay reward to the winner.
     /// @dev This logic is derived from Pokemon.
-    function _payRewards(PlayerId winner, PlayerId loser) internal {
+    function _payRewards(address winner, address loser) internal {
         // Calculate the reward balance of the winner.
         uint16 winnerTotalLevel = _totalLevel(winner);
         uint16 loserTotalLevel = _totalLevel(loser);
@@ -447,54 +439,55 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
         // Pokemon inspired reward calculation.
         uint48 top = 51 *
             uint48(loserTotalLevel) *
-            (uint48(loserTotalLevel) * 2 + 102)**3;
+            (uint48(loserTotalLevel) * 2 + 102) ** 3;
         uint48 bottom = (uint48(winnerTotalLevel) +
             uint48(loserTotalLevel) +
-            102)**3;
+            102) ** 3;
 
         // Dealer pay rewards to the winner.
-        dealer.payReward(_playerAddr(winner), uint256(top / bottom));
+        dealer.payReward(winner, uint256(top / bottom));
     }
 
     /// @notice Function to pay reward to both players when draws.
     /// @dev This logic is derived from Pokemon.
     function _payRewardsDraw() internal {
+        address _enemyAddr = enemyAddr[msg.sender];
         // Calculate the reward balance of both players.
-        uint16 homeTotalLevel = _totalLevel(PlayerId.Home);
-        uint16 visitorTotalLevel = _totalLevel(PlayerId.Visitor);
+        uint16 myTotalLevel = _totalLevel(msg.sender);
+        uint16 enemyTotalLevel = _totalLevel(_enemyAddr);
 
         // Pokemon inspired reward calculation.
         uint48 homeTop = 51 *
-            uint48(homeTotalLevel) *
-            (uint48(homeTotalLevel) * 2 + 102)**3;
+            uint48(myTotalLevel) *
+            (uint48(myTotalLevel) * 2 + 102) ** 3;
         uint48 visitorTop = 51 *
-            uint48(visitorTotalLevel) *
-            (uint48(visitorTotalLevel) * 2 + 102)**3;
-        uint48 bottom = (uint48(homeTotalLevel) +
-            uint48(visitorTotalLevel) +
-            102)**3;
+            uint48(enemyTotalLevel) *
+            (uint48(enemyTotalLevel) * 2 + 102) ** 3;
+        uint48 bottom = (uint48(myTotalLevel) +
+            uint48(enemyTotalLevel) +
+            102) ** 3;
 
         // The total amount of rewards are smaller then non-draw case.
         // Dealer pay rewards to both players.
-        dealer.payReward(_playerAddr(PlayerId.Home), homeTop / bottom / 3);
-        dealer.payReward(
-            _playerAddr(PlayerId.Visitor),
-            visitorTop / bottom / 3
-        );
+        dealer.payReward(msg.sender, homeTop / bottom / 3);
+        dealer.payReward(_enemyAddr, visitorTop / bottom / 3);
     }
 
     /// @notice Function to mark the slot used in the current round as used.
     /// @dev This function is called before step round.
-    function _markSlot(PlayerId playerId) internal {
-        Choice choice = choiceCommitLog[numRounds][playerId].choice;
+    function _markSlot(address player) internal {
+        uint8 numRounds = manager.getNumRounds(player);
+        Choice choice = manager.getChoiceCommitChoice(player);
         if (choice == Choice.Random) {
-            playerInfoTable[playerId].randomSlot.usedRound = numRounds + 1;
+            manager.setPlayerInfoRandomSlotUsedRound(player, numRounds + 1);
         } else if (choice == Choice.Hidden) {
             revert("Unreachable!");
         } else {
-            playerInfoTable[playerId].fixedSlotsUsedRounds[uint8(choice)] =
-                numRounds +
-                1;
+            manager.setPlayerInfoFixedSlotUsedRound(
+                player,
+                uint8(choice),
+                numRounds + 1
+            );
         }
     }
 
@@ -503,217 +496,175 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
     function _isLateForPlayerSeedCommit() internal view returns (bool) {
         return
             block.number >
-            playerSeedCommitFromBlock + PLAYER_SEED_COMMIT_TIME_LIMIT;
+            manager.getPlayerSeedCommitFromBlock(msg.sender) +
+                PLAYER_SEED_COMMIT_TIME_LIMIT;
     }
 
     /// @notice Function to detect late choice commitment.
     function _isLateForChoiceCommit() internal view returns (bool) {
         return
             block.number >
-            choiceCommitFromBlocks[numRounds] + CHOICE_COMMIT_TIME_LIMIT;
+            manager.getCommitFromBlock(msg.sender) + CHOICE_COMMIT_TIME_LIMIT;
     }
 
     /// @notice Function to detect late choice revealment.
     function _isLateForChoiceReveal() internal view returns (bool) {
         return
             block.number >
-            choiceRevealFromBlocks[numRounds] + CHOICE_REVEAL_TIME_LIMIT;
-    }
-
-    /// @notice function to get enemy's playerId.
-    function _enemyId(PlayerId playerId) internal pure returns (PlayerId) {
-        return playerId == PlayerId.Home ? PlayerId.Visitor : PlayerId.Home;
+            manager.getRevealFromBlock(msg.sender) + CHOICE_REVEAL_TIME_LIMIT;
     }
 
     /// @notice Function to calculate the total level of the fixed slots.
-    /// @param playerId: The player's identifier.
-    function _totalLevel(PlayerId playerId) internal view returns (uint16) {
+    /// @param player: The player's address
+    function _totalLevel(address player) internal view returns (uint16) {
         uint16 totalLevel = 0;
         for (uint8 slotIdx = 0; slotIdx < FIXED_SLOTS_NUM; slotIdx++) {
-            totalLevel += token
-                .getPriorCharacterInfo(
-                    _fixedSlotTokenIdByIdx(playerId, slotIdx),
-                    _fromBlock(playerId)
-                )
-                .level;
+            totalLevel += _fixedSlotCharInfoByIdx(player, slotIdx).level;
         }
         return totalLevel;
     }
 
-    /// @notice Function to return the player's remainingLevelPoint.
-    /// @param playerId: The player's identifier.
-    function _remainingLevelPoint(PlayerId playerId)
+    function _battleState()
         internal
         view
-        returns (uint8)
+        returns (IPLMBattleField.BattleState)
     {
-        return playerInfoTable[playerId].remainingLevelPoint;
+        return manager.getBattleState(msg.sender);
     }
 
-    function _nonce(PlayerId playerId) internal view returns (bytes32) {
+    /// @notice Function to return the player's remainingLevelPoint.
+    /// @param player: The player's address.
+    function _remainingLevelPoint(
+        address player
+    ) internal view returns (uint8) {
+        return manager.getPlayerInfoRemainingLevelPoint(msg.sender);
+    }
+
+    function _nonce(address player) internal view returns (bytes32) {
         require(
-            _randomSlotState(playerId) != RandomSlotState.NotSet,
+            _randomSlotState(player) != RandomSlotState.NotSet,
             "Nonce hasn't been set"
         );
-        return playerInfoTable[playerId].randomSlot.nonce;
+        return manager.getPlayerInfoRandomSlotNonce(msg.sender);
     }
 
     /// @notice Function to return the character information used in this round.
-    /// @param playerId: The player's identifier.
-    function _chosenCharacterInfo(PlayerId playerId)
-        internal
-        view
-        returns (IPLMData.CharacterInfoMinimal memory)
-    {
-        Choice choice = choiceCommitLog[numRounds][playerId].choice;
+    /// @param player: The player's address.
+    function _chosenCharacterInfo(
+        address player
+    ) internal view returns (IPLMData.CharacterInfoMinimal memory) {
+        Choice choice = manager.getChoiceCommitChoice(player);
 
         if (choice == Choice.Random) {
             // Player's choice is in a random slot.
-            return token.minimalizeCharInfo(_randomSlotCharInfo(playerId));
+            return token.minimalizeCharInfo(_randomSlotCharInfo(player));
         } else if (choice == Choice.Hidden) {
             revert("Unreachable");
         } else {
             // Player's choice is in fixed slots.
             return
                 token.minimalizeCharInfo(
-                    _fixedSlotCharInfoByIdx(playerId, uint8(choice))
+                    _fixedSlotCharInfoByIdx(player, uint8(choice))
                 );
         }
     }
 
-    function _totalSupplyAtFromBlock(PlayerId playerId)
-        internal
-        view
-        returns (uint256)
-    {
+    function _totalSupplyAtFromBlock(
+        address player
+    ) internal view returns (uint256) {
         // Here we assume that Bob is always a requester.
-        return token.getPriorTotalSupply(_fromBlock(playerId));
+        return token.getPriorTotalSupply(_fromBlock(player));
     }
 
-    function _randomSlotCharInfo(PlayerId playerId)
-        internal
-        view
-        returns (IPLMToken.CharacterInfo memory)
-    {
+    function _randomSlotCharInfo(
+        address player
+    ) internal view returns (IPLMToken.CharacterInfo memory) {
         require(
-            _randomSlotState(playerId) == RandomSlotState.Revealed,
+            _randomSlotState(player) == RandomSlotState.Revealed,
             "playerSeed hasn't been revealed yet"
         );
 
-        // Calculate the tokenId of random slot for player designated by PlayerId.
+        // Calculate the tokenId of random slot for player designated by player.
         uint256 tokenId = PLMSeeder.getRandomSlotTokenId(
-            _nonce(playerId),
-            _playerSeed(playerId),
-            _totalSupplyAtFromBlock(playerId)
+            _nonce(player),
+            _playerSeed(player),
+            _totalSupplyAtFromBlock(player)
         );
 
         IPLMToken.CharacterInfo memory playerCharInfo = token
-            .getPriorCharacterInfo(tokenId, _fromBlock(playerId));
-        playerCharInfo.level = _randomSlotLevel(playerId);
+            .getPriorCharacterInfo(tokenId, _fromBlock(player));
+        playerCharInfo.level = _randomSlotLevel(player);
 
         return playerCharInfo;
     }
 
-    function _randomSlotState(PlayerId playerId)
-        internal
-        view
-        returns (RandomSlotState)
-    {
-        return playerInfoTable[playerId].randomSlot.state;
+    function _randomSlotState(
+        address player
+    ) internal view returns (RandomSlotState) {
+        return manager.getPlayerInfoRandomSlotState(player);
     }
 
-    function _randomSlotLevel(PlayerId playerId) internal view returns (uint8) {
-        return playerInfoTable[playerId].randomSlot.level;
+    function _randomSlotLevel(address player) internal view returns (uint8) {
+        return manager.getPlayerInfoRandomSlotLevel(player);
     }
 
-    function _randomSlotIsUsed(PlayerId playerId) internal view returns (bool) {
-        return _randomSlotUsedRound(playerId) > 0;
+    function _randomSlotUsedRound(
+        address player
+    ) internal view returns (uint8) {
+        return manager.getPlayerInfoRandomSlotUsedRound(player);
     }
 
-    function _randomSlotUsedRound(PlayerId playerId)
-        internal
-        view
-        returns (uint8)
-    {
-        return playerInfoTable[playerId].randomSlot.usedRound;
+    function _winCount(address player) internal view returns (uint8) {
+        return manager.getPlayerInfoWinCount(player);
     }
 
-    function _winCount(PlayerId playerId) internal view returns (uint8) {
-        return playerInfoTable[playerId].winCount;
-    }
-
-    function _playerSeed(PlayerId playerId) internal view returns (bytes32) {
+    function _playerSeed(address player) internal view returns (bytes32) {
         require(
-            _randomSlotState(playerId) == RandomSlotState.Revealed,
+            _randomSlotState(player) == RandomSlotState.Revealed,
             "playerSeed hasn't revealed yet"
         );
-        return playerSeedCommitLog[playerId].playerSeed;
+        return manager.getPlayerSeedCommit(player).playerSeed;
     }
 
-    function _playerState(PlayerId playerId)
-        internal
-        view
-        returns (PlayerState)
-    {
-        return playerInfoTable[playerId].state;
+    function _playerState(address player) internal view returns (PlayerState) {
+        return manager.getPlayerInfoPlayerState(player);
     }
 
-    function _playerAddr(PlayerId playerId) internal view returns (address) {
-        return playerInfoTable[playerId].addr;
-    }
-
-    function _fixedSlotTokenIdByIdx(PlayerId playerId, uint8 slotIdx)
-        internal
-        view
-        returns (uint256)
-    {
+    function _fixedSlotTokenIdByIdx(
+        address player,
+        uint8 slotIdx
+    ) internal view returns (uint256) {
         require(slotIdx < FIXED_SLOTS_NUM, "Invalid fixed slot index");
-        return playerInfoTable[playerId].fixedSlots[slotIdx];
+        return manager.getPlayerInfoFixedSlots(player)[slotIdx];
     }
 
-    function _fixedSlotOfIdxIsUsed(PlayerId playerId, uint8 slotIdx)
-        internal
-        view
-        returns (bool)
-    {
-        return _fixedSlotUsedRoundByIdx(playerId, slotIdx) > 0;
+    function _fixedSlotUsedRoundByIdx(
+        address player,
+        uint8 slotIdx
+    ) internal view returns (uint8) {
+        return manager.getPlayerInfoFixedSlotsUsedRounds(player)[slotIdx];
     }
 
-    function _fixedSlotUsedRoundByIdx(PlayerId playerId, uint8 slotIdx)
-        internal
-        view
-        returns (uint8)
-    {
-        return playerInfoTable[playerId].fixedSlotsUsedRounds[slotIdx];
+    function _fromBlock(address player) internal view returns (uint256) {
+        return manager.getPlayerInfoFromBlock(player);
     }
 
-    function _fromBlock(PlayerId playerId) internal view returns (uint256) {
-        return playerInfoTable[playerId].fromBlock;
-    }
-
-    function _fixedSlotCharInfoByIdx(PlayerId playerId, uint8 slotIdx)
-        internal
-        view
-        returns (IPLMToken.CharacterInfo memory)
-    {
+    function _fixedSlotCharInfoByIdx(
+        address player,
+        uint8 slotIdx
+    ) internal view returns (IPLMToken.CharacterInfo memory) {
         return
             token.getPriorCharacterInfo(
-                _fixedSlotTokenIdByIdx(playerId, slotIdx),
-                _fromBlock(playerId)
+                _fixedSlotTokenIdByIdx(player, slotIdx),
+                _fromBlock(player)
             );
     }
 
-    function _bondLevelAtBattleStart(uint8 level, uint256 fromBlock)
-        internal
-        view
-        returns (uint32)
-    {
-        return
-            data.getPriorBondLevel(
-                level,
-                fromBlock,
-                _fromBlock(PlayerId.Visitor)
-            );
+    function _bondLevelAtBattleStart(
+        uint8 level,
+        uint256 fromBlock
+    ) internal view returns (uint32) {
+        return data.getPriorBondLevel(level, fromBlock, _fromBlock(msg.sender));
     }
 
     //////////////////////////////
@@ -721,87 +672,82 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
     //////////////////////////////
 
     /// @notice Commit the player's seed to generate the tokenId for random slot.
-    /// @param playerId: The player's identifier.
-    /// @param commitString: commitment string calculated by the player designated by playerId
+    /// @param commitString: commitment string calculated by the player designated by player
     ///                      as keccak256(abi.encodePacked(msg.sender, playerSeed)).
-    function commitPlayerSeed(PlayerId playerId, bytes32 commitString)
-        external
-        nonReentrant
-        onlyPlayerOf(playerId)
-    {
+    function commitPlayerSeed(
+        bytes32 commitString
+    ) external nonReentrantForEachBattle onlyPlayerOf {
         // Check that the battle hasn't started yet.
         require(
-            battleState == BattleState.Standby,
+            _battleState() == BattleState.Standby,
             "Battle has already started."
         );
-
+        address _enemyAddr = enemyAddr[msg.sender];
         // Check that the player seed hasn't set yet.
         require(
-            _randomSlotState(playerId) == RandomSlotState.NotSet,
+            _randomSlotState(msg.sender) == RandomSlotState.NotSet,
             "playerSeed has already been set."
         );
 
-        PlayerId enemyId = _enemyId(playerId);
-
+        uint256 _battleId = battleId[msg.sender];
         // Check that player seed commitment is in time.
         if (_isLateForPlayerSeedCommit()) {
-            emit LatePlayerSeedCommitDetected(playerId);
+            emit LatePlayerSeedCommitDetected(_battleId, msg.sender);
 
-            if (_randomSlotState(enemyId) == RandomSlotState.NotSet) {
+            if (_randomSlotState(_enemyAddr) == RandomSlotState.NotSet) {
                 // Both players are delayers.
-                emit LatePlayerSeedCommitDetected(enemyId);
+                emit LatePlayerSeedCommitDetected(_battleId, _enemyAddr);
                 _dealWithDelayersAndCancelBattle();
             } else {
-                // Deal with the delayer (the player designated by playerId) and
+                // Deal with the delayer (the player designated by player) and
                 // cancel this battle.
-                _dealWithDelayerAndCancelBattle(playerId);
+                _dealWithDelayerAndCancelBattle(msg.sender);
             }
             return;
         }
 
         // Save commitment on the storage. The playerSeed of the player is hidden in the commit phase.
-        playerSeedCommitLog[playerId] = PlayerSeedCommit(
-            commitString,
-            bytes32(0)
+        manager.setPlayerSeedCommit(
+            msg.sender,
+            PlayerSeedCommit(commitString, bytes32(0))
         );
 
-        // Emit the event that tells frontend that the player designated by playerId has committed.
-        emit PlayerSeedCommitted(playerId);
+        // Emit the event that tells frontend that the player designated by player has committed.
+        emit PlayerSeedCommitted(_battleId, msg.sender);
 
         // Update the state of the random slot to be commited.
-        playerInfoTable[playerId].randomSlot.state = RandomSlotState.Committed;
+        manager.setPlayerInfoRandomSlotState(
+            msg.sender,
+            RandomSlotState.Committed
+        );
 
         // Generate nonce after player committed the playerSeed.
         bytes32 nonce = PLMSeeder.randomFromBlockHash();
 
         // Emit the event that tells frontend that the randomSlotNonce is generated for the player designated
-        // by playerId.
-        emit RandomSlotNounceGenerated(playerId, nonce);
+        // by player.
+        emit RandomSlotNounceGenerated(_battleId, msg.sender, nonce);
 
-        playerInfoTable[playerId].randomSlot.nonce = nonce;
+        manager.setPlayerInfoRandomSlotNonce(msg.sender, nonce);
 
         // If both players have already committed their player seeds, start the battle.
-        if (_randomSlotState(enemyId) == RandomSlotState.Committed) {
-            battleState = BattleState.InRound;
+        if (_randomSlotState(_enemyAddr) == RandomSlotState.Committed) {
+            manager.setBattleState(msg.sender, BattleState.InRound);
         }
 
         // Set the block number when the round starts.
-        choiceCommitFromBlocks[numRounds] = block.number;
+        manager.setCommitFromBlock(msg.sender, block.number);
     }
 
-    /// @param playerId: The player's identifier.
-    /// @param playerSeed: the choice the player designated by playerId committed in this round.
+    /// @param playerSeed: the choice the player designated by player committed in this round.
     ///                    bytes32(0) is not allowed.
-    function revealPlayerSeed(PlayerId playerId, bytes32 playerSeed)
-        external
-        inRound
-        onlyPlayerOf(playerId)
-        readyForPlayerSeedReveal(playerId)
-    {
-        // The pointer to the commit log of the player designated by playerId.
-        PlayerSeedCommit storage playerSeedCommit = playerSeedCommitLog[
-            playerId
-        ];
+    function revealPlayerSeed(
+        bytes32 playerSeed
+    ) external inRound readyForPlayerSeedReveal onlyPlayerOf {
+        // The pointer to the commit log of the player designated by player.
+        PlayerSeedCommit memory playerSeedCommit = manager.getPlayerSeedCommit(
+            msg.sender
+        );
 
         // Check the commit has coincides with the one stored on chain.
         require(
@@ -811,223 +757,230 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
         );
 
         // Execute revealment
-        playerSeedCommit.playerSeed = playerSeed;
+        manager.setPlayerSeedCommitValue(msg.sender, playerSeed);
 
-        // Emit the event that tells frontend that the player designated by playerId has revealed.
-        emit PlayerSeedRevealed(numRounds, playerId, playerSeed);
+        // Emit the event that tells frontend that the player designated by player has revealed.
+        emit PlayerSeedRevealed(
+            battleId[msg.sender],
+            manager.getNumRounds(msg.sender),
+            msg.sender,
+            playerSeed
+        );
 
         // Update the state of the random slot to be revealed.
-        playerInfoTable[playerId].randomSlot.state = RandomSlotState.Revealed;
+        manager.setPlayerInfoRandomSlotState(
+            msg.sender,
+            RandomSlotState.Revealed
+        );
     }
 
     /// @notice Commit the choice (the character the player choose to use in the current round).
-    /// @param playerId: The player's identifier.
-    /// @param commitString: commitment string calculated by the player designated by playerId
+    /// @param commitString: commitment string calculated by the player designated by player
     ///                      as keccak256(abi.encodePacked(msg.sender, levelPoint, choice, blindingFactor)).
-    function commitChoice(PlayerId playerId, bytes32 commitString)
-        external
-        nonReentrant
-        inRound
-        onlyPlayerOf(playerId)
-    {
+    function commitChoice(
+        bytes32 commitString
+    ) external nonReentrantForEachBattle inRound onlyPlayerOf {
         // Check that the player who want to commit haven't committed yet in this round.
         require(
-            _playerState(playerId) == PlayerState.Standby,
+            _playerState(msg.sender) == PlayerState.Standby,
             "Player isn't ready for choice commit"
         );
+        address _enemyAddr = enemyAddr[msg.sender];
 
-        PlayerId enemyId = _enemyId(playerId);
-
+        uint8 numRounds = manager.getNumRounds(msg.sender);
+        uint256 _battleId = battleId[msg.sender];
         // Check that choice commitment is in time.
         if (_isLateForChoiceCommit()) {
-            emit LateChoiceCommitDetected(numRounds, playerId);
+            emit LateChoiceCommitDetected(_battleId, numRounds, msg.sender);
 
-            if (_playerState(enemyId) == PlayerState.Standby) {
+            if (_playerState(_enemyAddr) == PlayerState.Standby) {
                 // Both players are delayers.
-                emit LateChoiceCommitDetected(numRounds, enemyId);
+                emit LateChoiceCommitDetected(_battleId, numRounds, _enemyAddr);
                 _dealWithDelayersAndCancelBattle();
             } else {
-                // Deal with the delayer (the player designated by playerId) and
+                // Deal with the delayer (the player designated by player) and
                 // cancel this battle.
-                _dealWithDelayerAndCancelBattle(playerId);
+                _dealWithDelayerAndCancelBattle(msg.sender);
             }
             return;
         }
 
         // Save commitment on the storage. The choice of the player is hidden in the commit phase.
-        choiceCommitLog[numRounds][playerId] = ChoiceCommit(
-            commitString,
-            0,
-            Choice.Hidden
+        manager.setChoiceCommit(
+            msg.sender,
+            ChoiceCommit(commitString, 0, Choice.Hidden)
         );
 
-        // Emit the event that tells frontend that the player designated by playerId has committed.
-        emit ChoiceCommitted(numRounds, playerId);
+        // Emit the event that tells frontend that the player designated by player has committed.
+        emit ChoiceCommitted(_battleId, numRounds, msg.sender);
 
         // Update the state of the commit player to be committed.
-        playerInfoTable[playerId].state = PlayerState.Committed;
+        manager.setPlayerInfoState(msg.sender, PlayerState.Committed);
 
-        if (_playerState(enemyId) == PlayerState.Committed) {
+        if (_playerState(_enemyAddr) == PlayerState.Committed) {
             // both players have already committed.
-            choiceRevealFromBlocks[numRounds] = block.number;
+            manager.setRevealFromBlock(msg.sender, block.number);
         }
     }
 
     /// @notice Reveal the committed choice by the player who committed it in this round.
     /// @dev bindingFactor should be used only once. Reusing bindingFactor results in the security
     ///      vulnerability.
-    /// @param playerId: The player's identifier.
     /// @param levelPoint: the levelPoint the player uses to the chosen character.
-    /// @param choice: the choice the player designated by playerId committed in this round.
+    /// @param choice: the choice the player designated by player committed in this round.
     ///                Choice.Hidden is not allowed.
     /// @param bindingFactor: the secret factor (one-time) used in the generation of the commitment.
     function revealChoice(
-        PlayerId playerId,
         uint8 levelPoint,
         Choice choice,
         bytes32 bindingFactor
     )
         external
-        nonReentrant
+        nonReentrantForEachBattle
         inRound
-        onlyPlayerOf(playerId)
-        readyForChoiceReveal(playerId)
+        onlyPlayerOf
+        readyForChoiceReveal
     {
+        uint8 numRounds = manager.getNumRounds(msg.sender);
         // Choice.Hidden is not allowed for the choice passed to the reveal function.
         require(
             choice != Choice.Hidden,
             "Choice.Hidden isn't allowed when revealing"
         );
+        address _enemyAddr = enemyAddr[msg.sender];
+        uint256 _battleId = battleId[msg.sender];
+        {
+            // Check that choice revealment is in time.
+            if (_isLateForChoiceReveal()) {
+                emit LateChoiceRevealDetected(_battleId, numRounds, msg.sender);
 
-        PlayerId enemyId = _enemyId(playerId);
-
-        // Check that choice revealment is in time.
-        if (_isLateForChoiceReveal()) {
-            emit LateChoiceRevealDetected(numRounds, playerId);
-
-            if (_playerState(enemyId) == PlayerState.Committed) {
-                // Both players are delayers.
-                emit LateChoiceRevealDetected(numRounds, enemyId);
-                _dealWithDelayersAndCancelBattle();
-            } else {
-                // Deal with the delayer (the player designated by playerId) and
-                // cancel this battle.
-                _dealWithDelayerAndCancelBattle(playerId);
+                if (_playerState(_enemyAddr) == PlayerState.Committed) {
+                    // Both players are delayers.
+                    emit LateChoiceRevealDetected(
+                        _battleId,
+                        numRounds,
+                        _enemyAddr
+                    );
+                    _dealWithDelayersAndCancelBattle();
+                } else {
+                    // Deal with the delayer (the player designated by player) and
+                    // cancel this battle.
+                    _dealWithDelayerAndCancelBattle(msg.sender);
+                }
+                return;
             }
-            return;
         }
 
         // If the choice is the random slot, then random slot must have already been revealed.
         if (choice == Choice.Random) {
             require(
-                _randomSlotState(playerId) == RandomSlotState.Revealed,
+                _randomSlotState(msg.sender) == RandomSlotState.Revealed,
                 "Random slot can't be used because playerSeed hasn't been revealed yet"
             );
         }
 
-        // The pointer to the commit log of the player designated by playerId.
-        ChoiceCommit storage choiceCommit = choiceCommitLog[numRounds][
-            playerId
-        ];
+        // The pointer to the commit log of the player designated by player.
+        bytes32 choiceCommitString = manager.getChoiceCommitString(msg.sender);
 
         // Check the commit hash coincides with the one stored on chain.
         require(
             keccak256(
                 abi.encodePacked(msg.sender, levelPoint, choice, bindingFactor)
-            ) == choiceCommit.commitString,
+            ) == choiceCommitString,
             "Commit hash doesn't coincide"
         );
 
         // Check that the levelPoint is less than or equal to the remainingLevelPoint.
-        uint8 remainingLevelPoint = _remainingLevelPoint(playerId);
+        uint8 remainingLevelPoint = _remainingLevelPoint(msg.sender);
         if (levelPoint > remainingLevelPoint) {
             emit ExceedingLevelPointCheatDetected(
-                playerId,
+                _battleId,
+                msg.sender,
                 remainingLevelPoint,
                 levelPoint
             );
 
-            // Deal with the chater (the player designated by playerId) and cancel
+            // Deal with the chater (the player designated by player) and cancel
             // this battle.
-            _dealWithCheaterAndCancelBattle(playerId);
+            _dealWithCheaterAndCancelBattle(msg.sender);
             return;
         }
 
         // Subtract revealed levelPoint from remainingLevelPoint
-        playerInfoTable[playerId].remainingLevelPoint -= levelPoint;
+        manager.subtractPlayerInfoRemainingLevelPoint(msg.sender, levelPoint);
 
         // Check that the chosen slot hasn't been used yet.
-        // If the revealed slot has already used, then end this match and ban the player designated by playerId.
+        // If the revealed slot has already used, then end this match and ban the player designated by player.
         if (
-            (choice == Choice.Random && _randomSlotIsUsed(playerId)) ||
+            (choice == Choice.Random && _randomSlotUsedRound(msg.sender) > 0) ||
             (choice != Choice.Random &&
-                _fixedSlotOfIdxIsUsed(playerId, uint8(choice)))
+                _fixedSlotUsedRoundByIdx(msg.sender, uint8(choice)) > 0)
         ) {
-            emit ReusingUsedSlotCheatDetected(playerId, choice);
+            emit ReusingUsedSlotCheatDetected(_battleId, msg.sender, choice);
 
-            // Deal with the chater (the player designated by playerId) and cancel
+            // Deal with the chater (the player designated by player) and cancel
             // this battle.
-            _dealWithCheaterAndCancelBattle(playerId);
+            _dealWithCheaterAndCancelBattle(msg.sender);
             return;
         }
 
         // Execute revealment
-        choiceCommit.levelPoint = levelPoint;
-        choiceCommit.choice = choice;
+        manager.setChoiceCommitLevelPoint(msg.sender, levelPoint);
+        manager.setChoiceCommitChoice(msg.sender, choice);
 
-        // Emit the event that tells frontend that the player designated by playerId has revealed.
-        emit ChoiceRevealed(numRounds, playerId, levelPoint, choice);
+        // Emit the event that tells frontend that the player designated by player has revealed.
+        emit ChoiceRevealed(
+            _battleId,
+            numRounds,
+            msg.sender,
+            levelPoint,
+            choice
+        );
 
         // Update the state of the reveal player to be Revealed.
-        playerInfoTable[playerId].state = PlayerState.Revealed;
+        manager.setPlayerInfoState(msg.sender, PlayerState.Revealed);
 
         // If both players have already revealed their choices, then proceed to the damage
         // calculation.
-        if (_playerState(enemyId) == PlayerState.Revealed) {
+        if (_playerState(_enemyAddr) == PlayerState.Revealed) {
             _stepRound();
         }
     }
 
     /// @notice Function to report enemy player for late Seed Commit.
-    /// @dev TODO
-    /// @param enemyId: The player's identifier.
-    function reportLatePlayerSeedCommit(PlayerId enemyId)
-        external
-        standby
-        onlyPlayerOf(_enemyId(enemyId))
-    {
+    function reportLatePlayerSeedCommit() external standby onlyPlayerOf {
         // Detect enemy player's late player seed commit.
+        address _enemyAddr = enemyAddr[msg.sender];
         require(
-            _randomSlotState(enemyId) == RandomSlotState.NotSet &&
+            _randomSlotState(_enemyAddr) == RandomSlotState.NotSet &&
                 _isLateForPlayerSeedCommit(),
             "Reported player isn't late"
         );
 
-        emit LatePlayerSeedCommitDetected(enemyId);
+        emit LatePlayerSeedCommitDetected(battleId[msg.sender], _enemyAddr);
 
         // Deal with the delayer (enemy player) and cancel this battle.
-        _dealWithDelayerAndCancelBattle(enemyId);
+        _dealWithDelayerAndCancelBattle(_enemyAddr);
     }
 
     /// @notice Function to report enemy player for late commitment.
-    /// @dev TODO
-    /// @param enemyId: The player's identifier.
-    function reportLateChoiceCommit(PlayerId enemyId)
-        external
-        inRound
-        onlyPlayerOf(_enemyId(enemyId))
-    {
+    function reportLateChoiceCommit() external inRound onlyPlayerOf {
+        address _enemyAddr = enemyAddr[msg.sender];
         // Detect enemy player's late choice commit.
         require(
-            _playerState(enemyId) == PlayerState.Standby &&
+            _playerState(_enemyAddr) == PlayerState.Standby &&
                 _isLateForChoiceCommit(),
             "Reported player isn't late"
         );
 
-        emit LateChoiceCommitDetected(numRounds, enemyId);
+        emit LateChoiceCommitDetected(
+            battleId[msg.sender],
+            manager.getNumRounds(msg.sender),
+            _enemyAddr
+        );
 
         // Deal with the delayer (enemy player) and cancel this battle.
-        _dealWithDelayerAndCancelBattle(enemyId);
+        _dealWithDelayerAndCancelBattle(_enemyAddr);
     }
 
     /// @notice Function to report enemy player for late revealment.
@@ -1037,23 +990,23 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
     ///      choice revealmenet timelimit, then the delayer will be banned,
     ///      the battle will be canceled, and the stamina of the honest player will
     ///      be refunded.
-    /// @param enemyId: The player's identifier.
-    function reportLateReveal(PlayerId enemyId)
-        external
-        inRound
-        onlyPlayerOf(_enemyId(enemyId))
-    {
+    function reportLateReveal() external inRound onlyPlayerOf {
+        address _enemyAddr = enemyAddr[msg.sender];
         // Detect enemy player's late revealment.
         require(
-            _playerState(enemyId) == PlayerState.Committed &&
+            _playerState(_enemyAddr) == PlayerState.Committed &&
                 _isLateForChoiceReveal(),
             "Reported player isn't late"
         );
 
-        emit LateChoiceRevealDetected(numRounds, enemyId);
+        emit LateChoiceRevealDetected(
+            battleId[msg.sender],
+            manager.getNumRounds(msg.sender),
+            _enemyAddr
+        );
 
         // Deal with the delayer (enemy player) and cancel this battle.
-        _dealWithDelayerAndCancelBattle(enemyId);
+        _dealWithDelayerAndCancelBattle(_enemyAddr);
     }
 
     /// @notice Function to start the battle.
@@ -1071,7 +1024,19 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
         uint256 visitorFromBlock,
         uint256[4] memory homeFixedSlots,
         uint256[4] memory visitorFixedSlots
-    ) external readyForBattleStart onlyMatchOrganizer {
+    ) external onlyMatchOrganizer {
+        manager.beforeBattleStart(homeAddr, visitorAddr);
+        enemyAddr[homeAddr] = visitorAddr;
+        enemyAddr[visitorAddr] = homeAddr;
+
+        // register this battle to battle manager
+
+        battleId[homeAddr] = manager.getLatestBattle(homeAddr);
+        battleId[visitorAddr] = manager.getLatestBattle(visitorAddr);
+        require(
+            battleId[homeAddr] == battleId[visitorAddr],
+            "battleIds don't match"
+        );
         IPLMData.CharacterInfoMinimal[FIXED_SLOTS_NUM] memory homeCharInfos;
         IPLMData.CharacterInfoMinimal[FIXED_SLOTS_NUM] memory visitorCharInfos;
 
@@ -1091,218 +1056,70 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
             );
         }
 
-        // Get level point for both players.
-        uint8 homeLevelPoint = data.getLevelPoint(homeCharInfos);
-        uint8 visitorLevelPoint = data.getLevelPoint(visitorCharInfos);
+        {
+            // Get level point for both players.
+            uint8 homeLevelPoint = data.getLevelPoint(homeCharInfos);
 
-        // Initialize both players' information.
-        // Initialize random slots of them too.
-        playerInfoTable[PlayerId.Home] = PlayerInfo(
-            homeAddr,
-            homeFromBlock,
-            homeFixedSlots,
-            [0, 0, 0, 0],
-            RandomSlot(
-                data.getRandomSlotLevel(homeCharInfos),
-                bytes32(0),
-                0,
-                RandomSlotState.NotSet
-            ),
-            PlayerState.Standby,
-            0,
-            homeLevelPoint,
-            homeLevelPoint
-        );
-        playerInfoTable[PlayerId.Visitor] = PlayerInfo(
-            visitorAddr,
-            visitorFromBlock,
-            visitorFixedSlots,
-            [0, 0, 0, 0],
-            RandomSlot(
-                data.getRandomSlotLevel(visitorCharInfos),
-                bytes32(0),
-                0,
-                RandomSlotState.NotSet
-            ),
-            PlayerState.Standby,
-            0,
-            visitorLevelPoint,
-            visitorLevelPoint
-        );
-
-        // Change battle state to wait for the playerSeed commitment.
-        battleState = BattleState.Standby;
-
-        // Set the block number when the battle has started.
-        playerSeedCommitFromBlock = block.number;
-
-        // Reset round number.
-        numRounds = 0;
-
-        emit BattleStarted(homeAddr, visitorAddr);
-    }
-
-    ////////////////////////
-    ///      GETTERS     ///
-    ////////////////////////
-
-    function getBattleState() external view returns (BattleState) {
-        return battleState;
-    }
-
-    function getPlayerState(PlayerId playerId)
-        external
-        view
-        returns (PlayerState)
-    {
-        return _playerState(playerId);
-    }
-
-    function getRemainingLevelPoint(PlayerId playerId)
-        external
-        view
-        returns (uint256)
-    {
-        return _remainingLevelPoint(playerId);
-    }
-
-    function getNonce(PlayerId playerId) external view returns (bytes32) {
-        return _nonce(playerId);
-    }
-
-    function getFixedSlotCharInfo(PlayerId playerId)
-        external
-        view
-        returns (IPLMToken.CharacterInfo[FIXED_SLOTS_NUM] memory)
-    {
-        IPLMToken.CharacterInfo[FIXED_SLOTS_NUM] memory playerCharInfos;
-        for (uint8 slotIdx = 0; slotIdx < FIXED_SLOTS_NUM; slotIdx++) {
-            playerCharInfos[slotIdx] = _fixedSlotCharInfoByIdx(
-                playerId,
-                slotIdx
+            // Initialize both players' information.
+            // Initialize random slots of them too.
+            manager.setPlayerInfo(
+                homeAddr,
+                PlayerInfo(
+                    homeAddr,
+                    homeFromBlock,
+                    homeFixedSlots,
+                    [0, 0, 0, 0],
+                    RandomSlot(
+                        data.getRandomSlotLevel(homeCharInfos),
+                        bytes32(0),
+                        0,
+                        RandomSlotState.NotSet
+                    ),
+                    PlayerState.Standby,
+                    0,
+                    homeLevelPoint,
+                    homeLevelPoint
+                )
+            );
+        }
+        {
+            uint8 visitorLevelPoint = data.getLevelPoint(visitorCharInfos);
+            manager.setPlayerInfo(
+                visitorAddr,
+                PlayerInfo(
+                    visitorAddr,
+                    visitorFromBlock,
+                    visitorFixedSlots,
+                    [0, 0, 0, 0],
+                    RandomSlot(
+                        data.getRandomSlotLevel(visitorCharInfos),
+                        bytes32(0),
+                        0,
+                        RandomSlotState.NotSet
+                    ),
+                    PlayerState.Standby,
+                    0,
+                    visitorLevelPoint,
+                    visitorLevelPoint
+                )
             );
         }
 
-        return playerCharInfos;
+        // Change battle state to wait for the playerSeed commitment.
+        manager.setBattleState(homeAddr, BattleState.Standby);
+
+        // Set the block number when the battle has started.
+        manager.setPlayerSeedCommitFromBlock(homeAddr, block.number);
+
+        // Reset round number.
+        manager.setNumRounds(homeAddr, 0);
+
+        emit BattleStarted(battleId[msg.sender], homeAddr, visitorAddr);
     }
 
-    function getVirtualRandomSlotCharInfo(PlayerId playerId, uint256 tokenId)
-        external
-        view
-        returns (IPLMToken.CharacterInfo memory)
-    {
-        IPLMToken.CharacterInfo memory virtualPlayerCharInfo = token
-            .getPriorCharacterInfo(tokenId, _fromBlock(playerId));
-        virtualPlayerCharInfo.level = _randomSlotLevel(playerId);
-
-        return virtualPlayerCharInfo;
-    }
-
-    function getRandomSlotCharInfo(PlayerId playerId)
-        external
-        view
-        returns (IPLMToken.CharacterInfo memory)
-    {
-        return _randomSlotCharInfo(playerId);
-    }
-
-    function getCharsUsedRounds(PlayerId playerId)
-        external
-        view
-        returns (uint8[5] memory)
-    {
-        uint8[5] memory order;
-
-        // Fixed slots
-        for (uint8 slotIdx = 0; slotIdx < FIXED_SLOTS_NUM; slotIdx++) {
-            order[slotIdx] = _fixedSlotUsedRoundByIdx(playerId, slotIdx);
-        }
-
-        // Random slots
-        order[4] = _randomSlotUsedRound(playerId);
-
-        return order;
-    }
-
-    function getPlayerIdFromAddr(address playerAddr)
-        external
-        view
-        returns (PlayerId)
-    {
-        bytes32 playerAddrBytes = keccak256(abi.encodePacked(playerAddr));
-        bytes32 homeAddrBytes = keccak256(
-            abi.encodePacked(playerInfoTable[PlayerId.Home].addr)
-        );
-        bytes32 visitorAddrBytes = keccak256(
-            abi.encodePacked(playerInfoTable[PlayerId.Visitor].addr)
-        );
-        require(
-            playerAddrBytes == homeAddrBytes ||
-                playerAddrBytes == visitorAddrBytes,
-            "The player designated by playerAddr is not in the battle."
-        );
-        return
-            playerAddrBytes == homeAddrBytes ? PlayerId.Home : PlayerId.Visitor;
-    }
-
-    function getBondLevelAtBattleStart(uint8 level, uint256 fromBlock)
-        external
-        view
-        returns (uint32)
-    {
-        return _bondLevelAtBattleStart(level, fromBlock);
-    }
-
-    function getTotalSupplyAtFromBlock(PlayerId playerId)
-        external
-        view
-        returns (uint256)
-    {
-        return _totalSupplyAtFromBlock(playerId);
-    }
-
-    /// @dev 0-indexed
-    function getCurrentRound() external view returns (uint8) {
-        return numRounds;
-    }
-
-    function getMaxLevelPoint(PlayerId playerId) external view returns (uint8) {
-        return playerInfoTable[playerId].maxLevelPoint;
-    }
-
-    function getRoundResults() external view returns (RoundResult[] memory) {
-        RoundResult[] memory results = new RoundResult[](numRounds);
-        for (uint256 i = 0; i < numRounds; i++) {
-            results[i] = roundResults[i];
-        }
-        return results;
-    }
-
-    function getBattleResult() external view returns (BattleResult memory) {
-        return battleResult;
-    }
-
-    function getRandomSlotState(PlayerId playerId)
-        external
-        view
-        returns (RandomSlotState)
-    {
-        return _randomSlotState(playerId);
-    }
-
-    function getRandomSlotLevel(PlayerId playerId)
-        external
-        view
-        returns (uint8)
-    {
-        return _randomSlotLevel(playerId);
-    }
-
-    function supportsInterface(bytes4 interfaceId)
-        external
-        pure
-        returns (bool)
-    {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) external pure returns (bool) {
         return
             interfaceId == type(IERC165).interfaceId ||
             interfaceId == type(IPLMBattleField).interfaceId;
@@ -1319,10 +1136,9 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
     ///      Given contract address, this function checks that the contract supports
     ///      IPLMMatchOrganizer interface. If so, set the address as interface.
     /// @param _matchOrganizer: the contract address of PLMMatchOrganizer contract.
-    function setPLMMatchOrganizer(address _matchOrganizer)
-        external
-        onlyPolylemmers
-    {
+    function setPLMMatchOrganizer(
+        address _matchOrganizer
+    ) external onlyPolylemmers {
         require(
             IERC165(_matchOrganizer).supportsInterface(
                 type(IPLMMatchOrganizer).interfaceId
@@ -1338,10 +1154,10 @@ contract PLMBattleField is IPLMBattleField, ReentrancyGuard, IERC165 {
 
     // FIXME: remove this function after demo.
     function forceInitBattle() external {
-        battleState = BattleState.Settled;
-        matchOrganizer.forceResetMatchState(_playerAddr(PlayerId.Home));
-        matchOrganizer.forceResetMatchState(_playerAddr(PlayerId.Visitor));
-        emit BattleCanceled();
-        emit ForceInited();
+        manager.setBattleState(msg.sender, BattleState.Settled);
+        matchOrganizer.forceResetMatchState(msg.sender);
+        matchOrganizer.forceResetMatchState(enemyAddr[msg.sender]);
+        emit BattleCanceled(battleId[msg.sender]);
+        emit ForceInited(battleId[msg.sender]);
     }
 }

--- a/src/PLMBattleManager.sol
+++ b/src/PLMBattleManager.sol
@@ -1,0 +1,750 @@
+// SPDX-License-Idetifier: MIT
+pragma solidity ^0.8.17;
+pragma experimental ABIEncoderV2;
+
+import {IPLMDealer} from "./interfaces/IPLMDealer.sol";
+import {IPLMBattleStorage} from "./interfaces/IPLMBattleStorage.sol";
+import {IPLMBattleField} from "./interfaces/IPLMBattleField.sol";
+
+contract PLMBattleManager {
+    /// @notice List of IDs of battles the player has participated in. playerAddress => listIndex => battleID
+    mapping(address => mapping(uint256 => uint256)) private _joinedBattles;
+
+    /// @notice Mapping player address to Number of battles the player has participated in so far
+    mapping(address => uint256) private _numBattle;
+
+    /// @notice Mapping from battle ID to index of the joined battles list
+    mapping(uint256 => uint256) private _joinedBattlesIndex;
+
+    uint256 battleId;
+
+    address polylemmers;
+    address battleField;
+
+    IPLMBattleStorage strg;
+
+    constructor(IPLMBattleStorage _strg) {
+        strg = _strg;
+        polylemmers = msg.sender;
+    }
+
+    modifier onlyPolylemmers() {
+        require(msg.sender == polylemmers, "sender != polylemmers");
+        _;
+    }
+
+    modifier onlyBattleField() {
+        require(msg.sender == battleField, "sender != battleField");
+        _;
+    }
+
+    function battleOfPlayerByIndex(
+        address player,
+        uint256 index
+    ) public view virtual returns (uint256) {
+        return _joinedBattles[player][index];
+    }
+
+    function beforeBattleStart(
+        address home,
+        address visitor
+    ) external onlyBattleField {
+        battleId++;
+
+        _addBattleToPlayerEnumeration(home, battleId);
+        _addBattleToPlayerEnumeration(visitor, battleId);
+
+        strg.writeEnemyAddress(battleId, home, visitor);
+        strg.writeEnemyAddress(battleId, visitor, home);
+    }
+
+    /// @notice Obtain IDs of the most recent battles in which the player has participated
+    function getLatestBattle(address player) external view returns (uint256) {
+        return _latestBattle(player);
+    }
+
+    /**
+     * Add new battle ID to the list of IDs of battles in which the player has participated so far
+     * @param player address representing the new player of the given battle ID
+     * @param battleId uint256 ID of the battle to be added to the battles list of the given address
+     */
+    function _addBattleToPlayerEnumeration(
+        address player,
+        uint256 battleId
+    ) private {
+        uint256 length = _numBattle[player];
+        _joinedBattles[player][length] = battleId;
+        _joinedBattlesIndex[battleId] = length;
+    }
+
+    function _latestBattle(address player) internal view returns (uint256) {
+        return _joinedBattles[player][_numBattle[player]];
+    }
+
+    ///////////////////////
+    /// internal getter ///
+    ///////////////////////
+    function _getNumRounds(uint256 _battleId) internal view returns (uint8) {
+        try strg.loadNumRounds(_battleId) returns (uint8 numRounds) {
+            return numRounds;
+        } catch {
+            return 0;
+        }
+    }
+
+    function _getBattleState(
+        uint256 _battleId
+    ) internal view returns (IPLMBattleField.BattleState) {
+        try strg.loadBattleState(_battleId) returns (
+            IPLMBattleField.BattleState battleState
+        ) {
+            return battleState;
+        } catch {
+            return IPLMBattleField.BattleState.NotStarted;
+        }
+    }
+
+    function _getRoundResult(
+        uint256 _battleId,
+        uint8 indRound
+    ) internal view returns (IPLMBattleField.RoundResult memory) {
+        return strg.loadRoundResults(_battleId, indRound);
+    }
+
+    function _getBattleResult(
+        uint256 _battleId
+    ) internal view returns (IPLMBattleField.BattleResult memory) {
+        return strg.loadBattleResult(_battleId);
+    }
+
+    function _getPlayerSeedCommitFromBlock(
+        uint256 _battleId
+    ) internal view returns (uint256) {
+        return strg.loadPlayerSeedCommitFromBlock(_battleId);
+    }
+
+    function _getCommitFromBlock(
+        uint256 _battleId,
+        uint8 indRound
+    ) internal view returns (uint256) {
+        return strg.loadCommitFromBlocks(_battleId, indRound);
+    }
+
+    function _getRevealFromBlock(
+        uint256 _battleId,
+        uint8 indRound
+    ) internal view returns (uint256) {
+        return strg.loadRevealFromBlocks(_battleId, indRound);
+    }
+
+    function _getChoiceCommit(
+        uint256 _battleId,
+        uint8 indRound,
+        address player
+    ) internal view returns (IPLMBattleField.ChoiceCommit memory) {
+        return strg.loadChoiceCommitLog(_battleId, indRound, player);
+    }
+
+    function _getPlayerSeedCommit(
+        uint256 _battleId,
+        address player
+    ) internal view returns (IPLMBattleField.PlayerSeedCommit memory) {
+        return strg.loadPlayerSeedCommitLog(_battleId, player);
+    }
+
+    /// @notice When modifying a particular member of the structure, it is necessary to retrieve the data before the modification, so the internal function is implemented
+    function _getPlayerInfo(
+        uint256 _battleId,
+        address player
+    ) internal view returns (IPLMBattleField.PlayerInfo memory) {
+        return strg.loadPlayerInfoTable(_battleId, player);
+    }
+
+    function _getEnemyAddress(
+        uint256 _battleId,
+        address player
+    ) internal view returns (address) {
+        return strg.loadEnemyAddress(_battleId, player);
+    }
+
+    ////////////////////////////
+    /// WRITE/READ FUNCTIONS ///
+    ////////////////////////////
+    function setNumRounds(
+        address player,
+        uint8 numRound
+    ) external onlyBattleField {
+        strg.writeNumRounds(_latestBattle(player), numRound);
+    }
+
+    function incrementNumRounds(address player) external onlyBattleField {
+        uint256 _battleId = _latestBattle(player);
+        uint8 numRounds = _getNumRounds(_battleId);
+        strg.writeNumRounds(_battleId, numRounds + 1);
+    }
+
+    function setBattleState(
+        address player,
+        IPLMBattleField.BattleState battleState
+    ) external onlyBattleField {
+        strg.writeBattleState(_latestBattle(player), battleState);
+    }
+
+    function setRoundResult(
+        address player,
+        IPLMBattleField.RoundResult calldata roundResult
+    ) external onlyBattleField {
+        uint256 _battleId = _latestBattle(player);
+        strg.writeRoundResult(
+            _latestBattle(player),
+            _getNumRounds(_battleId),
+            roundResult
+        );
+    }
+
+    function setBattleResult(
+        address player,
+        IPLMBattleField.BattleResult calldata battleResult
+    ) external onlyBattleField {
+        strg.writeBattleResult(_latestBattle(player), battleResult);
+    }
+
+    function setPlayerSeedCommitFromBlock(
+        address player,
+        uint256 playerSeedCommitFromBlock
+    ) external onlyBattleField {
+        strg.writePlayerSeedCommitFromBlock(
+            _latestBattle(player),
+            playerSeedCommitFromBlock
+        );
+    }
+
+    function setCommitFromBlock(
+        address player,
+        uint256 commitFromBlock
+    ) external onlyBattleField {
+        uint256 _battleId = _latestBattle(player);
+        strg.writeCommitFromBlock(
+            _battleId,
+            _getNumRounds(_battleId),
+            commitFromBlock
+        );
+    }
+
+    function setRevealFromBlock(
+        address player,
+        uint256 revealFromBlock
+    ) external onlyBattleField {
+        uint256 _battleId = _latestBattle(player);
+        strg.writeRevealFromBlock(
+            _battleId,
+            _getNumRounds(_battleId),
+            revealFromBlock
+        );
+    }
+
+    function setChoiceCommit(
+        address player,
+        IPLMBattleField.ChoiceCommit calldata choiceCommit
+    ) external onlyBattleField {
+        uint256 _battleId = _latestBattle(player);
+        strg.writeChoiceCommitLog(
+            _battleId,
+            _getNumRounds(_battleId),
+            player,
+            choiceCommit
+        );
+    }
+
+    /// @notice PUT to modify a specific member of the structure.
+    function setChoiceCommitLevelPoint(
+        address player,
+        uint8 levelPoint
+    ) external onlyBattleField {
+        uint256 _battleId = _latestBattle(player);
+        uint8 indRound = _getNumRounds(_battleId);
+        IPLMBattleField.ChoiceCommit memory choiceCommit = _getChoiceCommit(
+            _battleId,
+            indRound,
+            player
+        );
+        choiceCommit.levelPoint = levelPoint;
+        strg.writeChoiceCommitLog(_battleId, indRound, player, choiceCommit);
+    }
+
+    /// @notice PUT to modify a specific member of the structure.
+    function setChoiceCommitChoice(
+        address player,
+        IPLMBattleField.Choice choice
+    ) external onlyBattleField {
+        uint256 _battleId = _latestBattle(player);
+        uint8 indRound = _getNumRounds(_battleId);
+        IPLMBattleField.ChoiceCommit memory choiceCommit = _getChoiceCommit(
+            _battleId,
+            indRound,
+            player
+        );
+        choiceCommit.choice = choice;
+        strg.writeChoiceCommitLog(_battleId, indRound, player, choiceCommit);
+    }
+
+    function setPlayerSeedCommit(
+        address player,
+        IPLMBattleField.PlayerSeedCommit calldata playerSeedCommit
+    ) external onlyBattleField {
+        uint256 _battleId = _latestBattle(player);
+        strg.writePlayerSeedCommitLog(_battleId, player, playerSeedCommit);
+    }
+
+    /// @notice PUT to modify a specific member of the structure.
+    function setPlayerSeedCommitValue(
+        address player,
+        bytes32 playerSeed
+    ) external onlyBattleField {
+        uint256 _battleId = _latestBattle(player);
+        IPLMBattleField.PlayerSeedCommit
+            memory playerSeedCommit = _getPlayerSeedCommit(_battleId, player);
+        playerSeedCommit.playerSeed = playerSeed;
+        strg.writePlayerSeedCommitLog(_battleId, player, playerSeedCommit);
+    }
+
+    function setPlayerInfo(
+        address player,
+        IPLMBattleField.PlayerInfo calldata playerInfo
+    ) external onlyBattleField {
+        uint256 _battleId = _latestBattle(player);
+        strg.writePlayerInfoTable(_battleId, player, playerInfo);
+    }
+
+    function incrementPlayerInfoWinCount(
+        address winner
+    ) external onlyBattleField {
+        uint256 _battleId = _latestBattle(winner);
+
+        IPLMBattleField.PlayerInfo memory playerInfo = _getPlayerInfo(
+            _battleId,
+            winner
+        );
+        playerInfo.winCount++;
+        strg.writePlayerInfoTable(_battleId, winner, playerInfo);
+    }
+
+    /// @notice PUT to modify a specific member of the structure.
+    function setPlayerInfoState(
+        address player,
+        IPLMBattleField.PlayerState playerState
+    ) external onlyBattleField {
+        uint256 _battleId = _latestBattle(player);
+        IPLMBattleField.PlayerInfo memory playerInfo = _getPlayerInfo(
+            _battleId,
+            player
+        );
+        playerInfo.state = playerState;
+        strg.writePlayerInfoTable(_battleId, player, playerInfo);
+    }
+
+    /// @notice PUT to modify a specific member of the structure.
+    function setPlayerInfoRandomSlotState(
+        address player,
+        IPLMBattleField.RandomSlotState state
+    ) external onlyBattleField {
+        uint256 _battleId = _latestBattle(player);
+        IPLMBattleField.PlayerInfo memory playerInfo = _getPlayerInfo(
+            _battleId,
+            player
+        );
+        playerInfo.randomSlot.state = state;
+        strg.writePlayerInfoTable(_battleId, player, playerInfo);
+    }
+
+    /// @notice PUT to modify a specific member of the structure.
+    function setPlayerInfoRandomSlotNonce(
+        address player,
+        bytes32 nonce
+    ) external onlyBattleField {
+        uint256 _battleId = _latestBattle(player);
+        IPLMBattleField.PlayerInfo memory playerInfo = _getPlayerInfo(
+            _battleId,
+            player
+        );
+        playerInfo.randomSlot.nonce = nonce;
+        strg.writePlayerInfoTable(_battleId, player, playerInfo);
+    }
+
+    /// @notice PUT to modify a specific member of the structure.
+    function setPlayerInfoRandomSlotUsedRound(
+        address player,
+        uint8 usedRound
+    ) external onlyBattleField {
+        uint256 _battleId = _latestBattle(player);
+        IPLMBattleField.PlayerInfo memory playerInfo = _getPlayerInfo(
+            _battleId,
+            player
+        );
+        playerInfo.randomSlot.usedRound = usedRound;
+        strg.writePlayerInfoTable(_battleId, player, playerInfo);
+    }
+
+    /// @notice PUT to modify a specific member of the structure.
+    function setPlayerInfoFixedSlotUsedRound(
+        address player,
+        uint8 slot,
+        uint8 usedRound
+    ) external onlyBattleField {
+        uint256 _battleId = _latestBattle(player);
+        IPLMBattleField.PlayerInfo memory playerInfo = _getPlayerInfo(
+            _battleId,
+            player
+        );
+        playerInfo.fixedSlotsUsedRounds[slot] = usedRound;
+        strg.writePlayerInfoTable(_battleId, player, playerInfo);
+    }
+
+    /// @notice PUT to modify a specific member of the structure.
+    function subtractPlayerInfoRemainingLevelPoint(
+        address player,
+        uint8 used
+    ) external onlyBattleField {
+        uint256 _battleId = _latestBattle(player);
+        IPLMBattleField.PlayerInfo memory playerInfo = _getPlayerInfo(
+            _battleId,
+            player
+        );
+        playerInfo.remainingLevelPoint -= used;
+        strg.writePlayerInfoTable(_battleId, player, playerInfo);
+    }
+
+    ////////////////////////////////
+    /////  get sender's data   /////
+    ////////////////////////////////
+    function getNumRounds(address player) external view returns (uint8) {
+        return _getNumRounds(_latestBattle(player));
+    }
+
+    function getBattleState(
+        address player
+    ) external view returns (IPLMBattleField.BattleState) {
+        return _getBattleState(_latestBattle(player));
+    }
+
+    function getRoundResult(
+        address player,
+        uint8 indRound
+    ) external view returns (IPLMBattleField.RoundResult memory) {
+        return _getRoundResult(_latestBattle(player), indRound);
+    }
+
+    function getBattleResult(
+        address player
+    ) external view returns (IPLMBattleField.BattleResult memory) {
+        return _getBattleResult(_latestBattle(player));
+    }
+
+    function getPlayerSeedCommitFromBlock(
+        address player
+    ) external view returns (uint256) {
+        return _getPlayerSeedCommitFromBlock(_latestBattle(player));
+    }
+
+    function getCommitFromBlock(
+        address player
+    ) external view returns (uint256) {
+        uint256 _battleId = _latestBattle(player);
+        return _getCommitFromBlock(_battleId, _getNumRounds(_battleId));
+    }
+
+    function getRevealFromBlock(
+        address player
+    ) external view returns (uint256) {
+        uint256 _battleId = _latestBattle(player);
+        return _getRevealFromBlock(_battleId, _getNumRounds(_battleId));
+    }
+
+    function getChoiceCommit(
+        address player,
+        uint8 indRound
+    ) external view returns (IPLMBattleField.ChoiceCommit memory) {
+        return _getChoiceCommit(_latestBattle(player), indRound, player);
+    }
+
+    function getChoiceCommitLevelPoint(
+        address player
+    ) external view returns (uint8) {
+        uint256 _battleId = _latestBattle(player);
+        return
+            _getChoiceCommit(_battleId, _getNumRounds(_battleId), player)
+                .levelPoint;
+    }
+
+    function getChoiceCommitChoice(
+        address player
+    ) external view returns (IPLMBattleField.Choice) {
+        uint256 _battleId = _latestBattle(player);
+        return
+            _getChoiceCommit(_battleId, _getNumRounds(_battleId), player)
+                .choice;
+    }
+
+    function getChoiceCommitString(
+        address player
+    ) external view returns (bytes32) {
+        uint256 _battleId = _latestBattle(player);
+        return
+            _getChoiceCommit(_battleId, _getNumRounds(_battleId), player)
+                .commitString;
+    }
+
+    function getPlayerSeedCommit(
+        address player
+    ) external view returns (IPLMBattleField.PlayerSeedCommit memory) {
+        uint256 _battleId = _latestBattle(player);
+        return _getPlayerSeedCommit(_battleId, player);
+    }
+
+    function getPlayerInfo(
+        address player
+    ) external view returns (IPLMBattleField.PlayerInfo memory) {
+        uint256 _battleId = _latestBattle(player);
+        return _getPlayerInfo(_battleId, player);
+    }
+
+    function getPlayerInfoAddress(
+        address player
+    ) external view returns (address) {
+        uint256 _battleId = _latestBattle(player);
+        return _getPlayerInfo(_battleId, player).addr;
+    }
+
+    function getPlayerInfoFromBlock(
+        address player
+    ) external view returns (uint256) {
+        uint256 _battleId = _latestBattle(player);
+        return _getPlayerInfo(_battleId, player).fromBlock;
+    }
+
+    function getPlayerInfoFixedSlots(
+        address player
+    ) external view returns (uint256[4] memory) {
+        uint256 _battleId = _latestBattle(player);
+        return _getPlayerInfo(_battleId, player).fixedSlots;
+    }
+
+    function getPlayerInfoFixedSlotsUsedRounds(
+        address player
+    ) external view returns (uint8[4] memory) {
+        uint256 _battleId = _latestBattle(player);
+        return _getPlayerInfo(_battleId, player).fixedSlotsUsedRounds;
+    }
+
+    function getPlayerInfoRandomSlot(
+        address player
+    ) external view returns (IPLMBattleField.RandomSlot memory) {
+        uint256 _battleId = _latestBattle(player);
+        return _getPlayerInfo(_battleId, player).randomSlot;
+    }
+
+    function getPlayerInfoRandomSlotNonce(
+        address player
+    ) external view returns (bytes32) {
+        uint256 _battleId = _latestBattle(player);
+        return _getPlayerInfo(_battleId, player).randomSlot.nonce;
+    }
+
+    function getPlayerInfoRandomSlotState(
+        address player
+    ) external view returns (IPLMBattleField.RandomSlotState) {
+        uint256 _battleId = _latestBattle(player);
+        return _getPlayerInfo(_battleId, player).randomSlot.state;
+    }
+
+    function getPlayerInfoRandomSlotLevel(
+        address player
+    ) external view returns (uint8) {
+        uint256 _battleId = _latestBattle(player);
+        return _getPlayerInfo(_battleId, player).randomSlot.level;
+    }
+
+    function getPlayerInfoRandomSlotUsedRound(
+        address player
+    ) external view returns (uint8) {
+        uint256 _battleId = _latestBattle(player);
+        return _getPlayerInfo(_battleId, player).randomSlot.usedRound;
+    }
+
+    function getPlayerInfoPlayerState(
+        address player
+    ) external view returns (IPLMBattleField.PlayerState) {
+        uint256 _battleId = _latestBattle(player);
+        return _getPlayerInfo(_battleId, player).state;
+    }
+
+    function getPlayerInfoWinCount(
+        address player
+    ) external view returns (uint8) {
+        uint256 _battleId = _latestBattle(player);
+        return _getPlayerInfo(_battleId, player).winCount;
+    }
+
+    function getPlayerInfoMaxLevelPoint(
+        address player
+    ) external view returns (uint8) {
+        uint256 _battleId = _latestBattle(player);
+        return _getPlayerInfo(_battleId, player).maxLevelPoint;
+    }
+
+    function getPlayerInfoRemainingLevelPoint(
+        address player
+    ) external view returns (uint8) {
+        uint256 _battleId = _latestBattle(player);
+        return _getPlayerInfo(_battleId, player).remainingLevelPoint;
+    }
+
+    function getEnemyAddress(address player) external view returns (address) {
+        return _getEnemyAddress(_latestBattle(player), player);
+    }
+
+    ////////////////////////////////
+    /////    get by battleId   /////
+    ////////////////////////////////
+    function getNumRoundsById(uint256 _battleId) external view returns (uint8) {
+        return _getNumRounds(_battleId);
+    }
+
+    function getBattleStateById(
+        uint256 _battleId
+    ) external view returns (IPLMBattleField.BattleState) {
+        return _getBattleState(_battleId);
+    }
+
+    function getRoundResultById(
+        uint256 _battleId,
+        uint8 indRound
+    ) external view returns (IPLMBattleField.RoundResult memory) {
+        return _getRoundResult(_battleId, indRound);
+    }
+
+    function getBattleResultById(
+        uint256 _battleId
+    ) external view returns (IPLMBattleField.BattleResult memory) {
+        return _getBattleResult(_battleId);
+    }
+
+    function getPlayerSeedCommitFromBlockById(
+        uint256 _battleId
+    ) external view returns (uint256) {
+        return _getPlayerSeedCommitFromBlock(_battleId);
+    }
+
+    function getCommitFromBlockById(
+        uint256 _battleId,
+        uint8 indRound
+    ) external view returns (uint256) {
+        return _getCommitFromBlock(_battleId, indRound);
+    }
+
+    function getRevealFromBlockById(
+        uint256 _battleId,
+        uint8 indRound
+    ) external view returns (uint256) {
+        return _getRevealFromBlock(_battleId, indRound);
+    }
+
+    function getChoiceCommitById(
+        uint256 _battleId,
+        uint8 indRound,
+        address player
+    ) external view returns (IPLMBattleField.ChoiceCommit memory) {
+        return _getChoiceCommit(_battleId, indRound, player);
+    }
+
+    function getPlayerSeedCommitById(
+        uint256 _battleId,
+        address player
+    ) external view returns (IPLMBattleField.PlayerSeedCommit memory) {
+        return _getPlayerSeedCommit(_battleId, player);
+    }
+
+    function getPlayerInfoById(
+        uint256 _battleId,
+        address player
+    ) external view returns (IPLMBattleField.PlayerInfo memory) {
+        return _getPlayerInfo(_battleId, player);
+    }
+
+    function getPlayerInfoAddressById(
+        uint256 _battleId,
+        address player
+    ) external view returns (address) {
+        return _getPlayerInfo(_battleId, player).addr;
+    }
+
+    function getPlayerInfoFromBlockById(
+        uint256 _battleId,
+        address player
+    ) external view returns (uint256) {
+        return _getPlayerInfo(_battleId, player).fromBlock;
+    }
+
+    function getPlayerInfoFixedSlotsById(
+        uint256 _battleId,
+        address player
+    ) external view returns (uint256[4] memory) {
+        return _getPlayerInfo(_battleId, player).fixedSlots;
+    }
+
+    function getPlayerInfoFixedSlotsUsedRoundsById(
+        uint256 _battleId,
+        address player
+    ) external view returns (uint8[4] memory) {
+        return _getPlayerInfo(_battleId, player).fixedSlotsUsedRounds;
+    }
+
+    function getPlayerInfoRandomSlotById(
+        uint256 _battleId,
+        address player
+    ) external view returns (IPLMBattleField.RandomSlot memory) {
+        return _getPlayerInfo(_battleId, player).randomSlot;
+    }
+
+    function getPlayerInfoPlayerStateById(
+        uint256 _battleId,
+        address player
+    ) external view returns (IPLMBattleField.PlayerState) {
+        return _getPlayerInfo(_battleId, player).state;
+    }
+
+    function getPlayerInfoWinCountById(
+        uint256 _battleId,
+        address player
+    ) external view returns (uint8) {
+        return _getPlayerInfo(_battleId, player).winCount;
+    }
+
+    function getPlayerInfoMaxLevelPointById(
+        uint256 _battleId,
+        address player
+    ) external view returns (uint8) {
+        return _getPlayerInfo(_battleId, player).maxLevelPoint;
+    }
+
+    function getPlayerInfoRemainingLevelPointById(
+        uint256 _battleId,
+        address player
+    ) external view returns (uint8) {
+        return _getPlayerInfo(_battleId, player).remainingLevelPoint;
+    }
+
+    function getEnemyAddress(
+        uint256 _battleId,
+        address player
+    ) external view returns (address) {
+        return _getEnemyAddress(_battleId, player);
+    }
+
+    /////////////////////////
+    ////  setter for req ////
+    /////////////////////////
+    function setPLMBattleField(address _battleField) external onlyPolylemmers {
+        battleField = _battleField;
+    }
+}

--- a/src/PLMBattleStorage.sol
+++ b/src/PLMBattleStorage.sol
@@ -1,0 +1,485 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+pragma experimental ABIEncoderV2;
+
+import {SSTORE2} from "lib/sstore2/contracts/SSTORE2.sol";
+import {IPLMBattleField} from "./interfaces/IPLMBattleField.sol";
+import {Utils} from "./lib/Utils.sol";
+
+contract PLMBattleStorage {
+    /// @notice SSTORE2 pointer to the numRounds referenced by battleId
+    mapping(uint256 => address) private pointerNumRounds;
+
+    /// @notice SSTORE2 pointer to the battleState referenced by battleId
+    mapping(uint256 => address) private pointerBattleState;
+
+    /// @notice SSTORE2 pointer to the round result referenced by battleId, indRound
+    mapping(uint256 => mapping(uint256 => address)) private pointerRoundResults;
+
+    /// @notice SSTORE2 pointer to the battle result referenced by battleId
+    mapping(uint256 => address) private pointerBattleResult;
+
+    /// @notice SSTORE2 pointer to the playerSeedCommitFromBlock referenced by battleId
+    mapping(uint256 => address) private pointerPlayerSeedCommitFromBlock;
+
+    /// @notice SSTORE2 pointer to the commitFromBlock referenced by battleId, indRound
+    mapping(uint256 => mapping(uint8 => address))
+        private pointerCommitFromBlocks;
+
+    /// @notice SSTORE2 pointer to the revealFromBlock referenced by battleId, indRound
+    mapping(uint256 => mapping(uint8 => address))
+        private pointerRevealFromBlocks;
+
+    /// @notice SSTORE2 pointer to the choiceCommit referenced by battleId, indRound, Player address
+    mapping(uint256 => mapping(uint8 => mapping(address => address)))
+        private pointerChoiceCommitLog;
+
+    /// @notice SSTORE2 pointer to the playerSeedCommit referenced by battleId, Player address
+    mapping(uint256 => mapping(address => address))
+        private pointerPlayerSeedCommitLog;
+
+    /// @notice SSTORE2 pointer to the playerInfo referenced by battleId, Player address
+    mapping(uint256 => mapping(address => address))
+        private pointerPlayerInfoTable;
+
+    /// @notice enemy address referenced by playerAddress
+    mapping(uint256 => mapping(address => address)) private pointerEnemyAddress;
+
+    /// @notice BattleManager Contract's address
+    address battleManager;
+
+    /// @notice Deployer's address
+    address polylemmer;
+
+    modifier onlyBattleManager() {
+        require(msg.sender == battleManager, "sender != managerContract");
+        _;
+    }
+
+    constructor() {
+        polylemmer = msg.sender;
+    }
+
+    ////////////////////////////////////////////////
+    ///      Encoding/Decoding strucut, enum     ///
+    ////////////////////////////////////////////////
+    /**
+     * Encoding, Decoding系はinternalとするべきだが，calldataを引数に取ることができるのが仕様上externalだけであり，
+     * それぞれの関数で必須なbytesのスライスがcalldataにしか実装されていないため，externalで定義している．
+     */
+
+    function _encodeBattleState(
+        IPLMBattleField.BattleState bs
+    ) external pure returns (bytes memory) {
+        return abi.encodePacked(uint256(bs));
+    }
+
+    function _encodeRoundResult(
+        IPLMBattleField.RoundResult calldata rr
+    ) external pure returns (bytes memory) {
+        return
+            abi.encodePacked(
+                rr.isDraw,
+                rr.winner,
+                rr.loser,
+                rr.winnerDamage,
+                rr.loserDamage
+            );
+    }
+
+    function _encodeBattleResult(
+        IPLMBattleField.BattleResult calldata br
+    ) external pure returns (bytes memory) {
+        return
+            abi.encodePacked(
+                br.numRounds,
+                br.isDraw,
+                br.winner,
+                br.loser,
+                br.winnerCount,
+                br.loserCount
+            );
+    }
+
+    function _encodeChoiceCommit(
+        IPLMBattleField.ChoiceCommit calldata cCommit
+    ) external pure returns (bytes memory) {
+        return
+            abi.encodePacked(
+                cCommit.commitString,
+                cCommit.levelPoint,
+                uint256(cCommit.choice)
+            );
+    }
+
+    function _encodePlayerSeedCommit(
+        IPLMBattleField.PlayerSeedCommit calldata psCommit
+    ) external pure returns (bytes memory) {
+        return abi.encodePacked(psCommit.commitString, psCommit.playerSeed);
+    }
+
+    function _encodePlayerInfo(
+        IPLMBattleField.PlayerInfo calldata playerInfo
+    ) external pure returns (bytes memory) {
+        bytes memory randomSlotEncoded = abi.encodePacked(
+            playerInfo.randomSlot.level, // 1byte
+            playerInfo.randomSlot.nonce, // 32bytes
+            playerInfo.randomSlot.usedRound, //1byte
+            uint256(playerInfo.randomSlot.state) // 32bytes
+        );
+        return
+            abi.encodePacked(
+                playerInfo.addr, //20bytes
+                playerInfo.fromBlock, //32bytes
+                playerInfo.fixedSlots, // [4] 32bytes
+                playerInfo.fixedSlotsUsedRounds, // [4] 1byte
+                randomSlotEncoded, //
+                uint256(playerInfo.state),
+                playerInfo.winCount,
+                playerInfo.maxLevelPoint,
+                playerInfo.remainingLevelPoint
+            );
+    }
+
+    function _encodeEnemyAddress(
+        address enemy
+    ) external pure returns (bytes memory) {
+        return abi.encodePacked(enemy);
+    }
+
+    function _decodeBattleState(
+        bytes calldata encoded
+    ) external pure returns (IPLMBattleField.BattleState) {
+        return IPLMBattleField.BattleState(Utils.bytesToUint(encoded));
+    }
+
+    function _decodeRoundResult(
+        bytes calldata encoded
+    ) external pure returns (IPLMBattleField.RoundResult memory) {
+        // RoundResult members: bool, address, address, uint32, uint32
+        return
+            IPLMBattleField.RoundResult({
+                isDraw: Utils.bytesToBool(encoded[0:1]),
+                winner: Utils.bytesToAddress(encoded[1:21]),
+                loser: Utils.bytesToAddress(encoded[21:41]),
+                winnerDamage: uint32(Utils.bytesToUint(encoded[41:45])),
+                loserDamage: uint32(Utils.bytesToUint(encoded[45:49]))
+            });
+    }
+
+    function _decodeBattleResult(
+        bytes calldata encoded
+    ) external pure returns (IPLMBattleField.BattleResult memory) {
+        return
+            IPLMBattleField.BattleResult({
+                numRounds: uint8(Utils.bytesToUint(encoded[0:1])),
+                isDraw: Utils.bytesToBool(encoded[1:2]),
+                winner: Utils.bytesToAddress(encoded[2:22]),
+                loser: Utils.bytesToAddress(encoded[22:42]),
+                winnerCount: uint8(Utils.bytesToUint(encoded[42:43])),
+                loserCount: uint8(Utils.bytesToUint(encoded[43:44]))
+            });
+    }
+
+    function _decodeChoiceCommit(
+        bytes calldata encoded
+    ) external pure returns (IPLMBattleField.ChoiceCommit memory) {
+        return
+            IPLMBattleField.ChoiceCommit({
+                commitString: bytes32(encoded[0:32]),
+                levelPoint: uint8(Utils.bytesToUint(encoded[32:33])),
+                choice: IPLMBattleField.Choice(
+                    Utils.bytesToUint(encoded[33:65])
+                )
+            });
+    }
+
+    function _decodePlayerSeedCommit(
+        bytes calldata encoded
+    ) external pure returns (IPLMBattleField.PlayerSeedCommit memory) {
+        return
+            IPLMBattleField.PlayerSeedCommit({
+                commitString: bytes32(encoded[0:32]),
+                playerSeed: bytes32(encoded[32:64])
+            });
+    }
+
+    function _decodePlayerInfo(
+        bytes calldata encoded
+    ) external pure returns (IPLMBattleField.PlayerInfo memory) {
+        return
+            IPLMBattleField.PlayerInfo({
+                addr: Utils.bytesToAddress(encoded[0:20]),
+                fromBlock: Utils.bytesToUint(encoded[20:52]),
+                fixedSlots: [
+                    Utils.bytesToUint(encoded[52:84]),
+                    Utils.bytesToUint(encoded[84:116]),
+                    Utils.bytesToUint(encoded[116:148]),
+                    Utils.bytesToUint(encoded[148:180])
+                ],
+                fixedSlotsUsedRounds: [
+                    uint8(Utils.bytesToUint(encoded[180:212])),
+                    uint8(Utils.bytesToUint(encoded[212:244])),
+                    uint8(Utils.bytesToUint(encoded[244:276])),
+                    uint8(Utils.bytesToUint(encoded[276:308]))
+                ],
+                randomSlot: IPLMBattleField.RandomSlot({
+                    level: uint8(Utils.bytesToUint(encoded[308:309])),
+                    nonce: bytes32(encoded[309:341]),
+                    usedRound: uint8(Utils.bytesToUint(encoded[341:342])),
+                    state: IPLMBattleField.RandomSlotState(
+                        Utils.bytesToUint(encoded[342:374])
+                    )
+                }),
+                state: IPLMBattleField.PlayerState(
+                    Utils.bytesToUint(encoded[374:406])
+                ),
+                winCount: uint8(Utils.bytesToUint(encoded[406:407])),
+                maxLevelPoint: uint8(Utils.bytesToUint(encoded[407:408])),
+                remainingLevelPoint: uint8(Utils.bytesToUint(encoded[408:409]))
+            });
+    }
+
+    function _decodeEnemyAddress(
+        bytes calldata encoded
+    ) external pure returns (address) {
+        return Utils.bytesToAddress(encoded[0:20]);
+    }
+
+    //////////////////////////////////
+    ///      Writer/Loader         ///
+    //////////////////////////////////
+    /// @notice store numRounds by SSTORE2. It is read only, so overwrite all data when updating.
+    function writeNumRounds(
+        uint256 battleId,
+        uint256 numRounds
+    ) external onlyBattleManager {
+        pointerNumRounds[battleId] = SSTORE2.write(abi.encodePacked(numRounds));
+    }
+
+    /// @notice store battleState by SSTORE2. It is read only, so overwrite all data when updating.
+    function writeBattleState(
+        uint256 battleId,
+        IPLMBattleField.BattleState battleState
+    ) external onlyBattleManager {
+        pointerBattleState[battleId] = SSTORE2.write(
+            this._encodeBattleState(battleState)
+        );
+    }
+
+    /// @notice store roundResult by SSTORE2. It is read only, so overwrite all data when updating.
+    function writeRoundResult(
+        uint256 battleId,
+        uint256 indRound,
+        IPLMBattleField.RoundResult calldata roundResult
+    ) external onlyBattleManager {
+        pointerRoundResults[battleId][indRound] = SSTORE2.write(
+            this._encodeRoundResult(roundResult)
+        );
+    }
+
+    /// @notice store battleResult by SSTORE2. It is read only, so overwrite all data when updating.
+    function writeBattleResult(
+        uint256 battleId,
+        IPLMBattleField.BattleResult calldata battleResult
+    ) external onlyBattleManager {
+        pointerBattleResult[battleId] = SSTORE2.write(
+            this._encodeBattleResult(battleResult)
+        );
+    }
+
+    /// @notice store playerSeedCommitFromBlock  by SSTORE2. It is read only, so overwrite all data when updating.
+    function writePlayerSeedCommitFromBlock(
+        uint256 battleId,
+        uint256 playerSeedCommitFromBlock
+    ) external onlyBattleManager {
+        pointerPlayerSeedCommitFromBlock[battleId] = SSTORE2.write(
+            abi.encodePacked(playerSeedCommitFromBlock)
+        );
+    }
+
+    /// @notice store CommitFromBlock by SSTORE2. It is read only, so overwrite all data when updating.
+    function writeCommitFromBlock(
+        uint256 battleId,
+        uint8 indRound,
+        uint256 commitFromBlock
+    ) external onlyBattleManager {
+        pointerCommitFromBlocks[battleId][indRound] = SSTORE2.write(
+            abi.encodePacked(commitFromBlock)
+        );
+    }
+
+    /// @notice store revealFromBlock  by SSTORE2. It is read only, so overwrite all data when updating.
+    function writeRevealFromBlock(
+        uint256 battleId,
+        uint8 indRound,
+        uint256 revealFromBlock
+    ) external onlyBattleManager {
+        pointerRevealFromBlocks[battleId][indRound] = SSTORE2.write(
+            abi.encodePacked(revealFromBlock)
+        );
+    }
+
+    /// @notice store ChoiceCommit by SSTORE2. It is read only, so overwrite all data when updating.
+    function writeChoiceCommitLog(
+        uint256 battleId,
+        uint8 indRound,
+        address player,
+        IPLMBattleField.ChoiceCommit calldata choiceCommit
+    ) external onlyBattleManager {
+        pointerChoiceCommitLog[battleId][indRound][player] = SSTORE2.write(
+            this._encodeChoiceCommit(choiceCommit)
+        );
+    }
+
+    /// @notice store PlayerSeedCommit by SSTORE2. It is read only, so overwrite all data when updating.
+    function writePlayerSeedCommitLog(
+        uint256 battleId,
+        address player,
+        IPLMBattleField.PlayerSeedCommit calldata playerSeedCommit
+    ) external onlyBattleManager {
+        pointerPlayerSeedCommitLog[battleId][player] = SSTORE2.write(
+            this._encodePlayerSeedCommit(playerSeedCommit)
+        );
+    }
+
+    /// @notice store PlayerInfo by SSTORE2. It is read only, so overwrite all data when updating.
+    function writePlayerInfoTable(
+        uint256 battleId,
+        address player,
+        IPLMBattleField.PlayerInfo calldata playerInfo
+    ) external onlyBattleManager {
+        pointerPlayerInfoTable[battleId][player] = SSTORE2.write(
+            this._encodePlayerInfo(playerInfo)
+        );
+    }
+
+    /// @notice store enemyAddress by SSTORE2. It is read only, so overwrite all data when updating.
+    function writeEnemyAddress(
+        uint256 battleId,
+        address player,
+        address enemy
+    ) external onlyBattleManager {
+        pointerEnemyAddress[battleId][player] = SSTORE2.write(
+            this._encodeEnemyAddress(enemy)
+        );
+    }
+
+    /// @notice load NumRounds by SSTORE2.
+    function loadNumRounds(uint256 battleId) external view returns (uint8) {
+        bytes memory loaded = SSTORE2.read(pointerNumRounds[battleId]);
+        return uint8(Utils.bytesToUint(loaded));
+    }
+
+    /// @notice load BattleState by SSTORE2.
+    function loadBattleState(
+        uint256 battleId
+    ) external view returns (IPLMBattleField.BattleState) {
+        bytes memory loaded = SSTORE2.read(pointerBattleState[battleId]);
+        return this._decodeBattleState(loaded);
+    }
+
+    /// @notice load Roundresults by SSTORE2.
+    function loadRoundResults(
+        uint256 battleId,
+        uint8 indRound
+    ) external view returns (IPLMBattleField.RoundResult memory) {
+        bytes memory loaded = SSTORE2.read(
+            pointerRoundResults[battleId][indRound]
+        );
+        return this._decodeRoundResult(loaded);
+    }
+
+    /// @notice load BattleResults by SSTORE2.
+    function loadBattleResult(
+        uint256 battleId
+    ) external view returns (IPLMBattleField.BattleResult memory) {
+        bytes memory loaded = SSTORE2.read(pointerBattleResult[battleId]);
+        return this._decodeBattleResult(loaded);
+    }
+
+    /// @notice load PlayerSeedCommitFromBlock by SSTORE2.
+    function loadPlayerSeedCommitFromBlock(
+        uint256 battleId
+    ) external view returns (uint256) {
+        bytes memory loaded = SSTORE2.read(
+            pointerPlayerSeedCommitFromBlock[battleId]
+        );
+        return Utils.bytesToUint(loaded);
+    }
+
+    /// @notice load CommitFromBlock by SSTORE2.
+    function loadCommitFromBlocks(
+        uint256 battleId,
+        uint8 indRound
+    ) external view returns (uint256) {
+        bytes memory loaded = SSTORE2.read(
+            pointerCommitFromBlocks[battleId][indRound]
+        );
+        return Utils.bytesToUint(loaded);
+    }
+
+    /// @notice load RevealFromBlock by SSTORE2.
+    function loadRevealFromBlocks(
+        uint256 battleId,
+        uint8 indRound
+    ) external view returns (uint256) {
+        bytes memory loaded = SSTORE2.read(
+            pointerRevealFromBlocks[battleId][indRound]
+        );
+        return Utils.bytesToUint(loaded);
+    }
+
+    /// @notice load ChoiceCommit by SSTORE2.
+    function loadChoiceCommitLog(
+        uint256 battleId,
+        uint8 indRound,
+        address player
+    ) external view returns (IPLMBattleField.ChoiceCommit memory) {
+        bytes memory loaded = SSTORE2.read(
+            pointerChoiceCommitLog[battleId][indRound][player]
+        );
+        return this._decodeChoiceCommit(loaded);
+    }
+
+    /// @notice load PlayerSeedCommit by SSTORE2.
+    function loadPlayerSeedCommitLog(
+        uint256 battleId,
+        address player
+    ) external view returns (IPLMBattleField.PlayerSeedCommit memory) {
+        bytes memory loaded = SSTORE2.read(
+            pointerPlayerSeedCommitLog[battleId][player]
+        );
+        return this._decodePlayerSeedCommit(loaded);
+    }
+
+    /// @notice load PlayerInfo by SSTORE2.
+    function loadPlayerInfoTable(
+        uint256 battleId,
+        address player
+    ) external view returns (IPLMBattleField.PlayerInfo memory) {
+        bytes memory loaded = SSTORE2.read(
+            pointerPlayerInfoTable[battleId][player]
+        );
+        return this._decodePlayerInfo(loaded);
+    }
+
+    /// @notice load BattleState by SSTORE2.
+    function loadEnemyAddress(
+        uint256 battleId,
+        address player
+    ) external view returns (address) {
+        bytes memory loaded = SSTORE2.read(
+            pointerEnemyAddress[battleId][player]
+        );
+        return this._decodeEnemyAddress(loaded);
+    }
+
+    ////////////////////////////
+    ////   set permission   ////
+    ////////////////////////////
+    function setBattleManager(address _battleManager) external {
+        require(msg.sender == polylemmer);
+        battleManager = _battleManager;
+    }
+}

--- a/src/PLMDealer.sol
+++ b/src/PLMDealer.sol
@@ -147,12 +147,10 @@ contract PLMDealer is PLMGacha, IPLMDealer {
         staminaFromBlock[player] = _safeSubUint256(block.number, restAmount);
     }
 
-    // TODO: utils
-    function _safeSubUint256(uint256 x, uint256 y)
-        internal
-        pure
-        returns (uint256)
-    {
+    function _safeSubUint256(
+        uint256 x,
+        uint256 y
+    ) internal pure returns (uint256) {
         if (x >= y) {
             return x - y;
         } else {
@@ -177,10 +175,9 @@ contract PLMDealer is PLMGacha, IPLMDealer {
     }
 
     /// @dev rewrite the retained block numbers that indicate the time when stamina is zero to shift it into the feature
-    function consumeStaminaForBattle(address player)
-        external
-        onlyMatchOrganizer
-    {
+    function consumeStaminaForBattle(
+        address player
+    ) external onlyMatchOrganizer {
         require(
             block.number >=
                 staminaFromBlock[player] +
@@ -240,11 +237,9 @@ contract PLMDealer is PLMGacha, IPLMDealer {
     ////////////////////////////////////
 
     /// @notice Function to get the subscription expired block number of the account.
-    function _subscExpiredBlock(address account)
-        internal
-        view
-        returns (uint256)
-    {
+    function _subscExpiredBlock(
+        address account
+    ) internal view returns (uint256) {
         return subscExpiredBlock[account];
     }
 
@@ -296,20 +291,16 @@ contract PLMDealer is PLMGacha, IPLMDealer {
     }
 
     /// @notice Function to get the subscription expired block number of the account.
-    function getSubscExpiredBlock(address account)
-        external
-        view
-        returns (uint256)
-    {
+    function getSubscExpiredBlock(
+        address account
+    ) external view returns (uint256) {
         return subscExpiredBlock[account];
     }
 
     /// @notice Function to get the number blocks remained until subscription expired block.
-    function getSubscRemainingBlockNum(address account)
-        external
-        view
-        returns (uint256)
-    {
+    function getSubscRemainingBlockNum(
+        address account
+    ) external view returns (uint256) {
         uint256 remainingBlockNum = block.number <= _subscExpiredBlock(account)
             ? _subscExpiredBlock(account) - block.number
             : 0;
@@ -332,9 +323,10 @@ contract PLMDealer is PLMGacha, IPLMDealer {
     /// @dev The distribution is determined in a progressive taxation manner.
     /// @param account: game player's account who charged MATIC to get PLMCoin.
     /// @param totalAmount: sum of the amount of PLMCoin distributed to the player and PLMCoin pool.
-    function _transferPLMCoinWithPooling(address account, uint256 totalAmount)
-        internal
-    {
+    function _transferPLMCoinWithPooling(
+        address account,
+        uint256 totalAmount
+    ) internal {
         // Calcuate how much PLMCoin are stored in the PLMCoin pool.
         uint256 leftAmount = _calcLeftAmount(totalAmount);
         uint256 poolingAmount = totalAmount - leftAmount;
@@ -345,11 +337,9 @@ contract PLMDealer is PLMGacha, IPLMDealer {
     }
 
     /// @notice Function to calculate the unpooled amount.
-    function _calcLeftAmount(uint256 totalAmount)
-        internal
-        view
-        returns (uint256)
-    {
+    function _calcLeftAmount(
+        uint256 totalAmount
+    ) internal view returns (uint256) {
         // get the pooling percentage from PLMData contract.
         uint256 poolingPercentage = _poolingPercentage(totalAmount);
         return (totalAmount * (100 - poolingPercentage)) / 100;
@@ -357,11 +347,9 @@ contract PLMDealer is PLMGacha, IPLMDealer {
 
     /// @notice get the percentage of pooling of PLMCoins minted when player charged
     ///         MATIC
-    function _poolingPercentage(uint256 amount)
-        internal
-        view
-        returns (uint256)
-    {
+    function _poolingPercentage(
+        uint256 amount
+    ) internal view returns (uint256) {
         if (0 < amount && amount <= 80) {
             return poolingPercentageTable[0];
         } else if (80 < amount && amount <= 160) {
@@ -410,10 +398,10 @@ contract PLMDealer is PLMGacha, IPLMDealer {
 
     /// @dev reward is paid from dealer conteract address
     ///      coin.transfer is not called directly bacause the function needs to be called by payer of reward, dealer.
-    function _tryPayReward(address winner, uint256 amount)
-        internal
-        returns (bool, uint256)
-    {
+    function _tryPayReward(
+        address winner,
+        uint256 amount
+    ) internal returns (bool, uint256) {
         uint256 balance = coin.balanceOf(address(this));
         bool success = balance >= amount;
         uint256 rewardAmount = success ? amount : balance;
@@ -436,10 +424,9 @@ contract PLMDealer is PLMGacha, IPLMDealer {
     /// @notice set match organizer contract address, function called by only Polylemmers EOA
     /// @dev   This function must be called when initializing contracts by the deployer manually. ("polylemmers" is contract deployer's address.)
     ///        "matchOrganizer" address is stored in this contract to make some functions able to be called from only matchOrganizer.
-    function setMatchOrganizer(address _matchOrganizer)
-        external
-        onlyPolylemmers
-    {
+    function setMatchOrganizer(
+        address _matchOrganizer
+    ) external onlyPolylemmers {
         matchOrganizer = _matchOrganizer;
     }
 

--- a/src/PLMMatchOrganizer.sol
+++ b/src/PLMMatchOrganizer.sol
@@ -66,14 +66,14 @@ contract PLMMatchOrganizer is IPLMMatchOrganizer, ReentrancyGuard, IERC165 {
         _;
     }
 
-    function _createProposal(address home, BattleProposal memory proposal)
-        internal
-    {
+    function _createProposal(
+        address home,
+        BattleProposal memory proposal
+    ) internal {
         proposals[home] = proposal;
         proposalsBoard.push(proposal);
     }
 
-    // FIXME: this function can be optimized.
     function _deleteProposal(address home) internal {
         uint256 ind = 0;
         for (uint256 i; i < proposalsBoard.length; i++) {
@@ -182,12 +182,10 @@ contract PLMMatchOrganizer is IPLMMatchOrganizer, ReentrancyGuard, IERC165 {
     /// if it passes all requirements for battle beginning, it calls startBattle()
     /// @param proposer the address of home whose proposal visitor wants to request against
     /// @param fixedSlots the character party that the visitor is gonna use in battle he requests to join.
-    function requestChallenge(address proposer, uint256[4] calldata fixedSlots)
-        external
-        nonReentrant
-        blockNumberIsPositive
-        subscribed
-    {
+    function requestChallenge(
+        address proposer,
+        uint256[4] calldata fixedSlots
+    ) external nonReentrant blockNumberIsPositive subscribed {
         // Check that the player designated by the address is truely a proposer.
         require(
             matchStates[proposer] == MatchState.Proposed,
@@ -278,10 +276,10 @@ contract PLMMatchOrganizer is IPLMMatchOrganizer, ReentrancyGuard, IERC165 {
     }
 
     /// @dev This function is called from battle field contract when settling the battle.
-    function resetMatchStates(address home, address visitor)
-        external
-        onlyBattleField
-    {
+    function resetMatchStates(
+        address home,
+        address visitor
+    ) external onlyBattleField {
         matchStates[home] = MatchState.NotInvolved;
         matchStates[visitor] = MatchState.NotInvolved;
     }
@@ -297,7 +295,6 @@ contract PLMMatchOrganizer is IPLMMatchOrganizer, ReentrancyGuard, IERC165 {
     ///      GETTER      ///
     ////////////////////////
 
-    // FIXME: this functio will be optimized in the future version.
     function getProposalList() external view returns (BattleProposal[] memory) {
         return proposalsBoard;
     }
@@ -306,11 +303,9 @@ contract PLMMatchOrganizer is IPLMMatchOrganizer, ReentrancyGuard, IERC165 {
         return matchStates[player];
     }
 
-    function supportsInterface(bytes4 interfaceId)
-        external
-        pure
-        returns (bool)
-    {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) external pure returns (bool) {
         return
             interfaceId == type(IERC165).interfaceId ||
             interfaceId == type(IPLMMatchOrganizer).interfaceId;

--- a/src/PLMToken.sol
+++ b/src/PLMToken.sol
@@ -508,7 +508,7 @@ contract PLMToken is ERC721Enumerable, IPLMToken, ReentrancyGuard {
         returns (CharacterInfo memory)
     {
         CharacterInfo memory dummyInfo = CharacterInfo(0, 0, 0, 0, 0, [0], "");
-        require(blockNumber < block.number, "blockNumber lager than latest");
+        require(blockNumber <= block.number, "blockNumber larger than latest");
 
         uint256[] memory numArgs = new uint256[](1);
         numArgs[0] = tokenId;

--- a/src/interfaces/IPLMBattleField.sol
+++ b/src/interfaces/IPLMBattleField.sol
@@ -23,12 +23,6 @@ interface IPLMBattleField {
         Revealed // 2
     }
 
-    /// @notice Enum to represent players' identities.
-    enum PlayerId {
-        Home, // 0
-        Visitor // 1
-    }
-
     /// @notice Players' states in each round.
     enum PlayerState {
         Standby, // 0
@@ -61,8 +55,8 @@ interface IPLMBattleField {
     /// @notice Struct to store the information on the winner and loser of each round
     struct RoundResult {
         bool isDraw;
-        PlayerId winner;
-        PlayerId loser;
+        address winner;
+        address loser;
         uint32 winnerDamage;
         uint32 loserDamage;
     }
@@ -71,8 +65,8 @@ interface IPLMBattleField {
     struct BattleResult {
         uint8 numRounds;
         bool isDraw;
-        PlayerId winner;
-        PlayerId loser;
+        address winner;
+        address loser;
         uint8 winnerCount;
         uint8 loserCount;
     }
@@ -107,78 +101,106 @@ interface IPLMBattleField {
     ///      EVENTS      ///
     ////////////////////////
 
-    event BattleStarted(address indexed homeAddr, address indexed visitorAddr);
-    event PlayerSeedCommitted(PlayerId indexed playerId);
-    event RandomSlotNounceGenerated(PlayerId playerId, bytes32 nonce);
+    event BattleStarted(
+        uint256 battleId,
+        address indexed homeAddr,
+        address indexed visitorAddr
+    );
+    event PlayerSeedCommitted(uint256 battleId, address indexed player);
+    event RandomSlotNounceGenerated(
+        uint256 battleId,
+        address player,
+        bytes32 nonce
+    );
     event PlayerSeedRevealed(
+        uint256 battleId,
         uint8 indexed numRounds,
-        PlayerId indexed playerId,
+        address indexed player,
         bytes32 playerSeed
     );
-    event ChoiceCommitted(uint8 indexed numRounds, PlayerId indexed playerId);
-    event ChoiceRevealed(
+    event ChoiceCommitted(
+        uint256 battleId,
         uint8 indexed numRounds,
-        PlayerId indexed playerId,
+        address indexed player
+    );
+    event ChoiceRevealed(
+        uint256 battleId,
+        uint8 indexed numRounds,
+        address indexed player,
         uint8 levelPoint,
         Choice choice
     );
     event RoundCompleted(
+        uint256 battleId,
         uint8 indexed numRounds,
         bool isDraw,
-        PlayerId winner,
-        PlayerId loser,
+        address winner,
+        address loser,
         uint32 winnerDamage,
         uint32 loserDamage
     );
     event BattleCompleted(
+        uint256 battleId,
         uint8 indexed numRounds,
         bool isDraw,
-        PlayerId winner,
-        PlayerId loser,
+        address winner,
+        address loser,
         uint8 winnerCount,
         uint8 loserCount
     );
 
     // Events for cheater detection.
     event ExceedingLevelPointCheatDetected(
-        PlayerId indexed cheater,
+        uint256 battleId,
+        address indexed cheater,
         uint8 remainingLevelPoint,
         uint8 cheaterLevelPoint
     );
     event ReusingUsedSlotCheatDetected(
-        PlayerId indexed cheater,
+        uint256 battlId,
+        address indexed cheater,
         Choice targetSlot
     );
 
     // Events for delayer detection.
-    event LatePlayerSeedCommitDetected(PlayerId indexed delayer);
-    event LateChoiceCommitDetected(uint8 numRounds, PlayerId indexed delayer);
-    event LateChoiceRevealDetected(uint8 numRounds, PlayerId indexed delayer);
-    event BattleCanceled();
-    event ForceInited();
+    event LatePlayerSeedCommitDetected(
+        uint256 battleId,
+        address indexed delayer
+    );
+    event LateChoiceCommitDetected(
+        uint256 battleId,
+        uint8 numRounds,
+        address indexed delayer
+    );
+    event LateChoiceRevealDetected(
+        uint256 battleId,
+        uint8 numRounds,
+        address indexed delayer
+    );
+    event BattleCanceled(uint256 battleId);
+    event ForceInited(uint256 battleId);
 
     //////////////////////////////
     /// BATTLE FIELD FUNCTIONS ///
     //////////////////////////////
 
-    function commitPlayerSeed(PlayerId playerId, bytes32 commitString) external;
+    function commitPlayerSeed(bytes32 commitString) external;
 
-    function revealPlayerSeed(PlayerId playerId, bytes32 playerSeed) external;
+    function revealPlayerSeed(bytes32 playerSeed) external;
 
-    function commitChoice(PlayerId playerId, bytes32 commitString) external;
+    function commitChoice(bytes32 commitString) external;
 
     function revealChoice(
-        PlayerId playerId,
         uint8 levelPoint,
         Choice choice,
         bytes32 bindingFactor
     ) external;
 
-    function reportLateReveal(PlayerId playerId) external;
+    function reportLateReveal() external;
 
-    function reportLatePlayerSeedCommit(PlayerId playerId) external;
+    function reportLatePlayerSeedCommit() external;
 
-    function reportLateChoiceCommit(PlayerId playerId) external;
+    function reportLateChoiceCommit() external;
 
     function startBattle(
         address homeAddr,
@@ -188,77 +210,6 @@ interface IPLMBattleField {
         uint256[4] calldata homeFixedSlots,
         uint256[4] calldata visitorFixedSlots
     ) external;
-
-    ////////////////////////
-    ///      GETTERS     ///
-    ////////////////////////
-
-    function getBattleState() external view returns (BattleState);
-
-    function getPlayerState(PlayerId playerId)
-        external
-        view
-        returns (PlayerState);
-
-    function getRemainingLevelPoint(PlayerId playerId)
-        external
-        view
-        returns (uint256);
-
-    function getNonce(PlayerId playerId) external view returns (bytes32);
-
-    function getFixedSlotCharInfo(PlayerId playerId)
-        external
-        view
-        returns (IPLMToken.CharacterInfo[4] memory);
-
-    function getVirtualRandomSlotCharInfo(PlayerId playerId, uint256 tokenId)
-        external
-        view
-        returns (IPLMToken.CharacterInfo memory);
-
-    function getRandomSlotCharInfo(PlayerId playerId)
-        external
-        view
-        returns (IPLMToken.CharacterInfo memory);
-
-    function getCharsUsedRounds(PlayerId playerId)
-        external
-        view
-        returns (uint8[5] memory);
-
-    function getPlayerIdFromAddr(address playerAddr)
-        external
-        view
-        returns (PlayerId);
-
-    function getBondLevelAtBattleStart(uint8 level, uint256 fromBlock)
-        external
-        view
-        returns (uint32);
-
-    function getTotalSupplyAtFromBlock(PlayerId playerId)
-        external
-        view
-        returns (uint256);
-
-    function getCurrentRound() external view returns (uint8);
-
-    function getMaxLevelPoint(PlayerId playerId) external view returns (uint8);
-
-    function getRoundResults() external view returns (RoundResult[] memory);
-
-    function getBattleResult() external view returns (BattleResult memory);
-
-    function getRandomSlotState(PlayerId playerId)
-        external
-        view
-        returns (RandomSlotState);
-
-    function getRandomSlotLevel(PlayerId playerId)
-        external
-        view
-        returns (uint8);
 
     ////////////////////////
     ///      SETTERS     ///

--- a/src/interfaces/IPLMBattleManager.sol
+++ b/src/interfaces/IPLMBattleManager.sol
@@ -1,0 +1,318 @@
+// SPDX-License-Idetifier: MIT
+pragma solidity ^0.8.17;
+pragma experimental ABIEncoderV2;
+
+import {IPLMDealer} from "./IPLMDealer.sol";
+import {IPLMBattleStorage} from "./IPLMBattleStorage.sol";
+
+import {IPLMBattleField} from "./IPLMBattleField.sol";
+
+interface IPLMBattleManager {
+    function battleOfPlayerByIndex(
+        address player,
+        uint256 index
+    ) external view returns (uint256);
+
+    function beforeBattleStart(address home, address visitor) external;
+
+    function getLatestBattle(address player) external view returns (uint256);
+
+    ////////////////////////////
+    /// WRITE/READ FUNCTIONS ///
+    ////////////////////////////
+
+    function setNumRounds(address player, uint8 numRound) external;
+
+    function incrementNumRounds(address player) external;
+
+    function setBattleState(
+        address player,
+        IPLMBattleField.BattleState bs
+    ) external;
+
+    function setRoundResult(
+        address player,
+        IPLMBattleField.RoundResult calldata rr
+    ) external;
+
+    function setBattleResult(
+        address player,
+        IPLMBattleField.BattleResult calldata br
+    ) external;
+
+    function setPlayerSeedCommitFromBlock(
+        address player,
+        uint256 playerSeedCommitFromBlock
+    ) external;
+
+    function setCommitFromBlock(
+        address player,
+        uint256 commitFromBlock
+    ) external;
+
+    function setRevealFromBlock(
+        address player,
+        uint256 revealFromBlock
+    ) external;
+
+    function setChoiceCommit(
+        address player,
+        IPLMBattleField.ChoiceCommit calldata choiceCommit
+    ) external;
+
+    function setChoiceCommitLevelPoint(
+        address player,
+        uint8 levelPoint
+    ) external;
+
+    function setChoiceCommitChoice(
+        address player,
+        IPLMBattleField.Choice choice
+    ) external;
+
+    function setPlayerSeedCommit(
+        address player,
+        IPLMBattleField.PlayerSeedCommit calldata playerSeedCommit
+    ) external;
+
+    function setPlayerSeedCommitValue(
+        address player,
+        bytes32 playerSeed
+    ) external;
+
+    function setPlayerInfo(
+        address player,
+        IPLMBattleField.PlayerInfo calldata playerInfo
+    ) external;
+
+    function incrementPlayerInfoWinCount(address player) external;
+
+    function setPlayerInfoState(
+        address player,
+        IPLMBattleField.PlayerState playerState
+    ) external;
+
+    function setPlayerInfoRandomSlotState(
+        address player,
+        IPLMBattleField.RandomSlotState state
+    ) external;
+
+    function setPlayerInfoRandomSlotNonce(
+        address player,
+        bytes32 nonce
+    ) external;
+
+    function setPlayerInfoRandomSlotUsedRound(
+        address player,
+        uint8 usedRound
+    ) external;
+
+    function setPlayerInfoFixedSlotUsedRound(
+        address player,
+        uint8 slot,
+        uint8 usedRound
+    ) external;
+
+    function subtractPlayerInfoRemainingLevelPoint(
+        address player,
+        uint8 used
+    ) external;
+
+    ////////////////////////////////
+    /////   get sender's data  /////
+    ////////////////////////////////
+    function getNumRounds(address player) external view returns (uint8);
+
+    function getBattleState(
+        address player
+    ) external view returns (IPLMBattleField.BattleState);
+
+    function getRoundResult(
+        address player,
+        uint8 indRound
+    ) external view returns (IPLMBattleField.RoundResult calldata);
+
+    function getBattleResult(
+        address player
+    ) external view returns (IPLMBattleField.BattleResult calldata);
+
+    function getPlayerSeedCommitFromBlock(
+        address player
+    ) external view returns (uint256);
+
+    function getCommitFromBlock(address player) external view returns (uint256);
+
+    function getRevealFromBlock(address player) external view returns (uint256);
+
+    function getChoiceCommit(
+        address player,
+        uint8 indRound
+    ) external view returns (IPLMBattleField.ChoiceCommit calldata);
+
+    function getChoiceCommitLevelPoint(
+        address player
+    ) external view returns (uint8);
+
+    function getChoiceCommitChoice(
+        address player
+    ) external view returns (IPLMBattleField.Choice);
+
+    function getChoiceCommitString(
+        address player
+    ) external view returns (bytes32);
+
+    function getPlayerSeedCommit(
+        address player
+    ) external view returns (IPLMBattleField.PlayerSeedCommit calldata);
+
+    function getPlayerInfo(
+        address player
+    ) external view returns (IPLMBattleField.PlayerInfo memory);
+
+    function getPlayerInfoAddress(
+        address player
+    ) external view returns (address);
+
+    function getPlayerInfoFromBlock(
+        address player
+    ) external view returns (uint256);
+
+    function getPlayerInfoFixedSlots(
+        address player
+    ) external view returns (uint256[4] memory);
+
+    function getPlayerInfoFixedSlotsUsedRounds(
+        address player
+    ) external view returns (uint8[4] memory);
+
+    function getPlayerInfoRandomSlot(
+        address player
+    ) external view returns (IPLMBattleField.RandomSlot memory);
+
+    function getPlayerInfoRandomSlotNonce(
+        address player
+    ) external view returns (bytes32);
+
+    function getPlayerInfoRandomSlotState(
+        address player
+    ) external view returns (IPLMBattleField.RandomSlotState);
+
+    function getPlayerInfoRandomSlotUsedRound(
+        address player
+    ) external view returns (uint8);
+
+    function getPlayerInfoRandomSlotLevel(
+        address player
+    ) external view returns (uint8);
+
+    function getPlayerInfoPlayerState(
+        address player
+    ) external view returns (IPLMBattleField.PlayerState);
+
+    function getPlayerInfoWinCount(
+        address player
+    ) external view returns (uint8);
+
+    function getPlayerInfoMaxLevelPoint(
+        address player
+    ) external view returns (uint8);
+
+    function getPlayerInfoRemainingLevelPoint(
+        address player
+    ) external view returns (uint8);
+
+    ////////////////////////////////
+    /////    get by battleId   /////
+    ////////////////////////////////
+    function getNumRoundsById(uint256 _battleId) external view returns (uint8);
+
+    function getBattleStateById(
+        uint256 _battleId
+    ) external view returns (IPLMBattleField.BattleState);
+
+    function getRoundResultById(
+        uint256 _battleId,
+        uint8 indRound
+    ) external view returns (IPLMBattleField.RoundResult calldata);
+
+    function getBattleResultById(
+        uint256 _battleId
+    ) external view returns (IPLMBattleField.BattleResult calldata);
+
+    function getPlayerSeedCommitFromBlockById(
+        uint256 _battleId
+    ) external view returns (uint256);
+
+    function getCommitFromBlockById(
+        uint256 _battleId,
+        uint8 indRound
+    ) external view returns (uint256);
+
+    function getRevealFromBlockById(
+        uint256 _battleId,
+        uint8 indRound
+    ) external view returns (uint256);
+
+    function getChoiceCommitById(
+        uint256 _battleId,
+        uint8 indRound,
+        address player
+    ) external view returns (IPLMBattleField.ChoiceCommit calldata);
+
+    function getPlayerSeedCommitById(
+        uint256 _battleId,
+        address player
+    ) external view returns (IPLMBattleField.PlayerSeedCommit calldata);
+
+    function getPlayerInfoById(
+        uint256 _battleId,
+        address player
+    ) external view returns (IPLMBattleField.PlayerInfo memory);
+
+    function getPlayerInfoAddressById(
+        uint256 _battleId,
+        address player
+    ) external view returns (address);
+
+    function getPlayerInfoFromBlockById(
+        uint256 _battleId,
+        address player
+    ) external view returns (uint256);
+
+    function getPlayerInfoFixedSlotsById(
+        uint256 _battleId,
+        address player
+    ) external view returns (uint256[4] memory);
+
+    function getPlayerInfoFixedSlotsUsedRoundsById(
+        uint256 _battleId,
+        address player
+    ) external view returns (uint8[4] memory);
+
+    function getPlayerInfoRandomSlotById(
+        uint256 _battleId,
+        address player
+    ) external view returns (IPLMBattleField.RandomSlot memory);
+
+    function getPlayerInfoPlayerStateById(
+        uint256 _battleId,
+        address player
+    ) external view returns (IPLMBattleField.PlayerState);
+
+    function getPlayerInfoWinCountById(
+        uint256 _battleId,
+        address player
+    ) external view returns (uint8);
+
+    function getPlayerInfoMaxLevelPointById(
+        uint256 _battleId,
+        address player
+    ) external view returns (uint8);
+
+    function getPlayerInfoRemainingLevelPointById(
+        uint256 _battleId,
+        address player
+    ) external view returns (uint8);
+
+    function setPLMBattleField(address _battleField) external;
+}

--- a/src/interfaces/IPLMBattleStorage.sol
+++ b/src/interfaces/IPLMBattleStorage.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+pragma experimental ABIEncoderV2;
+
+import {SSTORE2} from "lib/sstore2/contracts/SSTORE2.sol";
+import {IPLMBattleField} from "./IPLMBattleField.sol";
+
+interface IPLMBattleStorage {
+    function writeNumRounds(uint256 battleId, uint256 numRounds) external;
+
+    function writeBattleState(
+        uint256 battleId,
+        IPLMBattleField.BattleState battleState
+    ) external;
+
+    function writeRoundResult(
+        uint256 battleId,
+        uint256 infRound,
+        IPLMBattleField.RoundResult calldata roundResult
+    ) external;
+
+    function writeBattleResult(
+        uint256 battleId,
+        IPLMBattleField.BattleResult calldata battleResult
+    ) external;
+
+    function writePlayerSeedCommitFromBlock(
+        uint256 battleId,
+        uint256 playerSeedCommitFromBlock
+    ) external;
+
+    function writeCommitFromBlock(
+        uint256 battleId,
+        uint8 indRound,
+        uint256 commitFromBlock
+    ) external;
+
+    function writeRevealFromBlock(
+        uint256 battleId,
+        uint8 indRound,
+        uint256 revealFromBlock
+    ) external;
+
+    function writeChoiceCommitLog(
+        uint256 battleId,
+        uint8 indRound,
+        address player,
+        IPLMBattleField.ChoiceCommit calldata choiceCommit
+    ) external;
+
+    function writePlayerSeedCommitLog(
+        uint256 battleId,
+        address player,
+        IPLMBattleField.PlayerSeedCommit calldata playerSeedCommit
+    ) external;
+
+    function writePlayerInfoTable(
+        uint256 battleId,
+        address player,
+        IPLMBattleField.PlayerInfo calldata playerInfo
+    ) external;
+
+    function writeEnemyAddress(
+        uint256 battleId,
+        address player,
+        address enemy
+    ) external;
+
+    function loadNumRounds(uint256 battleId) external view returns (uint8);
+
+    function loadBattleState(
+        uint256 battleId
+    ) external view returns (IPLMBattleField.BattleState);
+
+    // TODO: roundのindexを他の箇所でもindRoundと書き直す
+    function loadRoundResults(
+        uint256 battleId,
+        uint8 indRound
+    ) external view returns (IPLMBattleField.RoundResult memory);
+
+    function loadBattleResult(
+        uint256 battleId
+    ) external view returns (IPLMBattleField.BattleResult memory);
+
+    function loadPlayerSeedCommitFromBlock(
+        uint256 battleId
+    ) external view returns (uint256);
+
+    function loadCommitFromBlocks(
+        uint256 battleId,
+        uint8 indRound
+    ) external view returns (uint256);
+
+    function loadRevealFromBlocks(
+        uint256 battleId,
+        uint8 indRound
+    ) external view returns (uint256);
+
+    function loadChoiceCommitLog(
+        uint256 battleId,
+        uint8 indRound,
+        address player
+    ) external view returns (IPLMBattleField.ChoiceCommit memory);
+
+    function loadPlayerSeedCommitLog(
+        uint256 battleId,
+        address player
+    ) external view returns (IPLMBattleField.PlayerSeedCommit memory);
+
+    function loadPlayerInfoTable(
+        uint256 battleId,
+        address player
+    ) external view returns (IPLMBattleField.PlayerInfo memory);
+
+    function loadEnemyAddress(
+        uint256 battleId,
+        address player
+    ) external view returns (address);
+
+    ////////////////////////////
+    ////   set permission   ////
+    ////////////////////////////
+    function setBattleManager(address _battleManager) external;
+}

--- a/src/interfaces/IPLMMatchOrganizer.sol
+++ b/src/interfaces/IPLMMatchOrganizer.sol
@@ -49,8 +49,10 @@ interface IPLMMatchOrganizer {
 
     function isNotInvolved(address player) external view returns (bool);
 
-    function requestChallenge(address proposer, uint256[4] calldata fixedSlots)
-        external;
+    function requestChallenge(
+        address proposer,
+        uint256[4] calldata fixedSlots
+    ) external;
 
     function resetMatchStates(address home, address visitor) external;
 

--- a/src/lib/PLMSeeder.sol
+++ b/src/lib/PLMSeeder.sol
@@ -11,11 +11,9 @@ library PLMSeeder {
         uint8 attribute;
     }
 
-    function _randomFromTokenId(uint256 tokenId)
-        internal
-        view
-        returns (uint256)
-    {
+    function _randomFromTokenId(
+        uint256 tokenId
+    ) internal view returns (uint256) {
         return
             uint256(
                 keccak256(
@@ -49,11 +47,10 @@ library PLMSeeder {
     /// @dev generate seeds of traits from current-block's hash for to mint character
     /// @param tokenId tokenId to be minted
     /// @return Seed the struct of trait seed that is indexId of trait array
-    function generateTokenSeed(uint256 tokenId, IPLMToken token)
-        external
-        view
-        returns (Seed memory)
-    {
+    function generateTokenSeed(
+        uint256 tokenId,
+        IPLMToken token
+    ) external view returns (Seed memory) {
         // fetch database interface
         IPLMData data = IPLMData(token.getDataAddr());
 

--- a/src/lib/Utils.sol
+++ b/src/lib/Utils.sol
@@ -35,7 +35,6 @@ library Utils {
         uint256 targetValue,
         address funcAddress
     ) public view returns (uint32, bool) {
-        console.log(msg.sender);
         uint32 numElements = _callGetLength(lengthFuncPacked, funcAddress);
 
         if (numElements == 0) {
@@ -128,5 +127,67 @@ library Utils {
             }
         }
         return abi.encodePacked(funcSig, packed);
+    }
+
+    function bytesToAddress(bytes calldata data)
+        external
+        pure
+        returns (address addr)
+    {
+        bytes memory b = data;
+        assembly {
+            addr := mload(add(b, 20))
+        }
+    }
+
+    function bytesToUint256(bytes calldata data)
+        external
+        pure
+        returns (uint256 num)
+    {
+        bytes memory b = data;
+        assembly {
+            num := mload(add(b, 0x20))
+        }
+    }
+
+    function bytesToUint32(bytes calldata data)
+        external
+        pure
+        returns (uint32 num)
+    {
+        bytes memory b = data;
+        assembly {
+            num := mload(add(b, 0x20))
+        }
+    }
+
+    function bytesToUint8(bytes calldata data)
+        external
+        pure
+        returns (uint8 num)
+    {
+        bytes memory b = data;
+        assembly {
+            num := mload(add(b, 0x20))
+        }
+    }
+
+    function bytesToBool(bytes calldata data) external pure returns (bool bin) {
+        bytes memory b = data;
+        assembly {
+            bin := mload(add(b, 0x20))
+        }
+    }
+
+    function bytesToUint(bytes memory b) internal pure returns (uint256) {
+        uint256 number;
+        for (uint256 i = 0; i < b.length; i++) {
+            number =
+                number +
+                uint256(uint8(b[i])) *
+                (2**(8 * (b.length - (i + 1))));
+        }
+        return number;
     }
 }

--- a/test/IntegrationMultiSlot.t.sol
+++ b/test/IntegrationMultiSlot.t.sol
@@ -1,0 +1,490 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+
+import "forge-std/Test.sol";
+import {PLMDealer} from "../src/PLMDealer.sol";
+import {PLMCoin} from "../src/PLMCoin.sol";
+import {PLMToken} from "../src/PLMToken.sol";
+import {PLMData} from "../src/PLMData.sol";
+import {PLMBattleManager} from "../src/PLMBattleManager.sol";
+import {PLMMatchOrganizer} from "../src/PLMMatchOrganizer.sol";
+import {PLMBattleField} from "../src/PLMBattleField.sol";
+import {PLMBattleStorage} from "../src/PLMBattleStorage.sol";
+import {PLMTypesV1} from "../src/data-contracts/PLMTypesV1.sol";
+import {PLMLevelsV1} from "../src/data-contracts/PLMLevelsV1.sol";
+
+import {IPLMCoin} from "../src/interfaces/IPLMCoin.sol";
+import {IPLMToken} from "../src/interfaces/IPLMToken.sol";
+import {IPLMDealer} from "../src/interfaces/IPLMDealer.sol";
+import {IPLMData} from "../src/interfaces/IPLMData.sol";
+import {IPLMBattleManager} from "../src/interfaces/IPLMBattleManager.sol";
+import {IPLMMatchOrganizer} from "../src/interfaces/IPLMMatchOrganizer.sol";
+import {IPLMBattleField} from "../src/interfaces/IPLMBattleField.sol";
+import {IPLMBattleStorage} from "../src/interfaces/IPLMBattleStorage.sol";
+import {IPLMTypes} from "../src/interfaces/IPLMTypes.sol";
+import {IPLMLevels} from "../src/interfaces/IPLMLevels.sol";
+
+contract MultiSlotTest is Test {
+    struct TestPlayer {
+        address addr;
+        IPLMBattleField.Choice[5] choices;
+        uint8[5] levelPoints;
+        bytes32 bindingFactor;
+        bytes32 playerSeed;
+    }
+
+    event Log(string message);
+
+    // FIXME: 定数はハードコードせずにbattleFieldを参照するべき．
+    uint256 constant PLAYER_SEED_COMMIT_TIME_LIMIT = 600;
+    uint256 constant CHOICE_COMMIT_TIME_LIMIT = 600;
+    uint256 constant CHOICE_REVEAL_TIME_LIMIT = 600;
+    uint256 currentBlock = 0;
+    uint256 maticForEx = 100000 ether;
+    address polylemmer = address(10);
+
+    PLMCoin coinContract;
+    PLMToken tokenContract;
+    PLMDealer dealerContract;
+    PLMData dataContract;
+    PLMTypesV1 typesContract;
+    PLMLevelsV1 levelsContract;
+
+    IPLMToken token;
+    IPLMCoin coin;
+    IPLMDealer dealer;
+    IPLMData data;
+    IPLMTypes types;
+    IPLMLevels levels;
+    IPLMBattleStorage strg;
+    IPLMBattleManager manager;
+
+    PLMBattleStorage strgContract;
+    PLMBattleManager managerContract;
+    PLMMatchOrganizer mo;
+    PLMBattleField bf;
+
+    TestPlayer home1 =
+        TestPlayer(
+            address(11),
+            [
+                IPLMBattleField.Choice.Fixed2, //1
+                IPLMBattleField.Choice.Fixed1, //0
+                IPLMBattleField.Choice.Random, //4
+                IPLMBattleField.Choice.Fixed3, //2
+                IPLMBattleField.Choice.Fixed4 //3
+            ],
+            [2, 2, 1, 1, 2],
+            bytes32("sdaskfjdiopfvj0pr2904738cdf"),
+            bytes32("sdaskfkfjdiopasdasdasdasds7df")
+        );
+
+    TestPlayer visitor1 =
+        TestPlayer(
+            address(12),
+            [
+                IPLMBattleField.Choice.Fixed1, //0
+                IPLMBattleField.Choice.Random, //4
+                IPLMBattleField.Choice.Fixed2, //1
+                IPLMBattleField.Choice.Fixed3, //2
+                IPLMBattleField.Choice.Fixed4 //3
+            ],
+            [2, 2, 1, 1, 2],
+            bytes32("sdaskfjdiopfvj0prsdas38cdf"),
+            bytes32("sdaskdfdshfljldifhbfodvdoi")
+        );
+    TestPlayer home2 =
+        TestPlayer(
+            address(21),
+            [
+                IPLMBattleField.Choice.Fixed2, //1
+                IPLMBattleField.Choice.Fixed1, //0
+                IPLMBattleField.Choice.Random, //4
+                IPLMBattleField.Choice.Fixed3, //2
+                IPLMBattleField.Choice.Fixed4 //3
+            ],
+            [2, 2, 1, 1, 2],
+            bytes32("sdaskfjdiopfvj0pr2904738cdf"),
+            bytes32("sdaskfkfjdiopasdasdasdasds7df")
+        );
+    TestPlayer visitor2 =
+        TestPlayer(
+            address(22),
+            [
+                IPLMBattleField.Choice.Fixed2, //1
+                IPLMBattleField.Choice.Random, //4
+                IPLMBattleField.Choice.Fixed3, //2
+                IPLMBattleField.Choice.Fixed1, //0
+                IPLMBattleField.Choice.Fixed4 //3
+            ],
+            [2, 2, 1, 1, 2],
+            bytes32("sdaskfjdfklsdjfpagr2904738cdf"),
+            bytes32("sdaskfdfioqudfsdadfdsdasds7df")
+        );
+
+    function setUp() public {
+        // send transaction by deployer
+        vm.startPrank(polylemmer);
+        // deploy contract
+        coinContract = new PLMCoin();
+        coin = IPLMCoin(address(coinContract));
+        typesContract = new PLMTypesV1();
+        types = IPLMTypes(address(typesContract));
+        levelsContract = new PLMLevelsV1();
+        levels = IPLMLevels(address(levelsContract));
+        dataContract = new PLMData(types, levels);
+        data = IPLMData(address(dataContract));
+        tokenContract = new PLMToken(coin, data, 100000);
+        token = IPLMToken(address(tokenContract));
+
+        // deploy battle system
+        strgContract = new PLMBattleStorage();
+        strg = IPLMBattleStorage(address(strgContract));
+        managerContract = new PLMBattleManager(strg);
+        manager = IPLMBattleManager(address(managerContract));
+        dealerContract = new PLMDealer(token, coin);
+        dealer = IPLMDealer(address(dealerContract));
+        mo = new PLMMatchOrganizer(dealer, token);
+        bf = new PLMBattleField(dealer, token, manager);
+
+        // set dealer
+        coin.setDealer(address(dealerContract));
+        token.setDealer(address(dealerContract));
+        dealer.setMatchOrganizer(address(mo));
+        dealer.setBattleField(address(bf));
+        mo.setPLMBattleField(address(bf));
+        bf.setPLMMatchOrganizer(address(mo));
+        manager.setPLMBattleField(address(bf));
+        strg.setBattleManager(address(manager));
+
+        // set block number to be enough length
+        currentBlock = dealerContract.getStaminaMax() * 300 + 1000;
+        vm.roll(currentBlock);
+        vm.stopPrank();
+
+        // initial mint of PLM
+        uint256 ammount = 1e20;
+        vm.prank(polylemmer);
+        dealerContract.mintAdditionalCoin(ammount);
+
+        // send ether to user address
+        vm.deal(home1.addr, 10000000 ether);
+        vm.deal(home2.addr, 10000000 ether);
+        vm.deal(visitor1.addr, 10000000 ether);
+        vm.deal(visitor2.addr, 10000000 ether);
+        // (user)  charge MATIC and get PLMcoin
+        vm.prank(home1.addr);
+        dealerContract.charge{value: maticForEx}();
+        vm.prank(visitor1.addr);
+        dealerContract.charge{value: maticForEx}();
+        vm.prank(home2.addr);
+        dealerContract.charge{value: maticForEx}();
+        vm.prank(visitor2.addr);
+        dealerContract.charge{value: maticForEx}();
+
+        //Prepare characters for debug
+        bytes20[4] memory names1 = [bytes20("a1"), "a2", "a3", "a4"];
+        bytes20[4] memory names2 = [bytes20("b1"), "b2", "b3", "b4"];
+        bytes20[4] memory names3 = [bytes20("c1"), "c2", "c3", "c4"];
+        bytes20[4] memory names4 = [bytes20("d1"), "d2", "d3", "d4"];
+        uint8[4] memory levels1 = [1, 2, 2, 8]; // sum: 13
+        uint8[4] memory levels2 = [3, 4, 5, 2]; // sum: 14
+        uint8[4] memory levels3 = [10, 11, 10, 4]; // sum: 35
+        uint8[4] memory levels4 = [3, 4, 2, 8]; // sum: 17
+
+        // home1
+        for (uint256 i = 0; i < names1.length; i++) {
+            _createCharacter(levels1[i], names1[i], home1);
+        }
+
+        // visitor1.addr
+        for (uint256 i = 0; i < names2.length; i++) {
+            _createCharacter(levels2[i], names2[i], visitor1);
+        }
+
+        // home2
+        for (uint256 i = 0; i < names3.length; i++) {
+            _createCharacter(levels3[i], names3[i], home2);
+        }
+        for (uint256 i = 0; i < names4.length; i++) {
+            _createCharacter(levels4[i], names4[i], visitor2);
+        }
+    }
+
+    // ２つのバトルが提案された時に，２つのバトルが適切に開始されるかどうか
+    // - すでに始まっているバトルに対してrequestChallengeした時，適切にrejectされるか
+    // - battle Idで２つのバトルの情報を適切に取得することができるか
+    // - battleは２つともはじまるか:state
+    // - ２つのバトルを適切に進めることができるか
+    // - 間違って他のバトルを参照しようとした時
+
+    // 複数人が同時にバトルを提案した時
+    function testMakeProposalByTwo() public {
+        _freeSubscribe(home1);
+        _freeSubscribe(visitor1);
+        _freeSubscribe(home2);
+        _freeSubscribe(visitor2);
+
+        // make 2 proposals
+        _createProposal(home1, 10, 40);
+        _createProposal(home2, 10, 40);
+
+        // get proposal list
+        IPLMMatchOrganizer.BattleProposal[] memory proposalList = mo
+            .getProposalList();
+
+        assertEq(
+            proposalList.length,
+            2,
+            "Proposal haven't registered properly."
+        );
+
+        // valid request
+        _requestChallenge(visitor1, home1);
+        bool e = true;
+        // invalid request, request to proposal already started.
+        _requestInvalidChallenge(visitor2, home1);
+
+        _requestChallenge(visitor2, home2);
+    }
+
+    function testMultiSlotBattles() public {
+        _freeSubscribe(home1);
+        _freeSubscribe(visitor1);
+        _freeSubscribe(home2);
+        _freeSubscribe(visitor2);
+
+        // make 2 proposals
+        _createProposal(home1, 10, 40);
+        _createProposal(home2, 10, 40);
+
+        // battles start
+        _requestChallenge(visitor1, home1);
+        _requestChallenge(visitor2, home2);
+
+        _twoBattleThread(home1, visitor1, home2, visitor2);
+        // _properTwoBattleFlowsTester(home1, visitor1.addr, home2, visitor2);
+
+        // vm.prank(home1);
+        // assertEq(uint256(manager.getBattleState()), 4, "not settled");
+        // vm.prank(home2);
+        // assertEq(uint256(manager.getBattleState()), 4, "not settled");
+    }
+
+    /////////////////////////
+    ////     UTILS      /////
+    /////////////////////////
+
+    function _freeSubscribe(TestPlayer storage user) internal {
+        vm.startPrank(address(dealerContract));
+        coin.transfer(user.addr, dealer.getSubscFeePerUnitPeriod());
+        vm.stopPrank();
+
+        vm.startPrank(user.addr);
+        coin.approve(
+            address(dealerContract),
+            dealer.getSubscFeePerUnitPeriod()
+        );
+        dealer.extendSubscPeriod();
+        vm.stopPrank();
+    }
+
+    function _createCharacter(
+        uint256 lev,
+        bytes20 name,
+        TestPlayer storage _owner
+    ) internal {
+        vm.startPrank(address(dealerContract));
+        uint256 tokenId = token.mint(name);
+        for (uint256 i; i < lev; i++) {
+            coin.approve(address(token), token.getNecessaryExp(tokenId));
+            token.updateLevel(tokenId);
+        }
+
+        token.transferFrom(address(dealerContract), _owner.addr, tokenId);
+        vm.stopPrank();
+    }
+
+    function _createProposal(
+        TestPlayer storage _home,
+        uint16 lower,
+        uint16 upper
+    ) internal {
+        // home(home) fixedslot
+        uint256[4] memory fixedSlotsOfhome = _createFixedSlots(_home);
+
+        currentBlock += 1;
+        vm.roll(currentBlock);
+
+        // propose battle
+        vm.prank(_home.addr);
+        mo.proposeBattle(lower, upper, fixedSlotsOfhome);
+    }
+
+    function _requestChallenge(
+        TestPlayer storage _visitor,
+        TestPlayer storage _home
+    ) internal {
+        uint256[4] memory fixedSlotsOfvisitor = _createFixedSlots(_visitor);
+        // pouse to goes by in blocktime
+        currentBlock += 1;
+        vm.roll(currentBlock);
+        currentBlock += 1;
+        vm.roll(currentBlock);
+
+        // request battle
+        vm.prank(_visitor.addr);
+        mo.requestChallenge(_home.addr, fixedSlotsOfvisitor);
+    }
+
+    function _requestInvalidChallenge(
+        TestPlayer storage _visitor,
+        TestPlayer storage _home
+    ) internal {
+        uint256[4] memory fixedSlotsOfvisitor = _createFixedSlots(_visitor);
+        // pouse to goes by in blocktime
+        currentBlock += 1;
+        vm.roll(currentBlock);
+        currentBlock += 1;
+        vm.roll(currentBlock);
+
+        // request battle
+        vm.prank(_visitor.addr);
+        try mo.requestChallenge(_home.addr, fixedSlotsOfvisitor) {
+            revert("invalid request accepted");
+        } catch {
+            emit Log("invalid request rejected properly");
+        }
+    }
+
+    function _createFixedSlots(
+        TestPlayer storage user
+    ) internal view returns (uint256[4] memory) {
+        uint256[4] memory fixedSlots;
+        for (uint256 i = 0; i < token.balanceOf(user.addr); i++) {
+            fixedSlots[i] = token.tokenOfOwnerByIndex(user.addr, i);
+        }
+        return fixedSlots;
+    }
+
+    function _twoBattleThread(
+        TestPlayer storage _home1,
+        TestPlayer storage _visitor1,
+        TestPlayer storage _home2,
+        TestPlayer storage _visitor2
+    ) internal {
+        //// pack commit seed string
+        //battle1
+        bytes32 commitSeedString1 = keccak256(
+            abi.encodePacked(_home1.addr, _home1.playerSeed)
+        );
+        bytes32 commitSeedString2 = keccak256(
+            abi.encodePacked(_visitor1.addr, _visitor1.playerSeed)
+        );
+        //battle2
+        bytes32 commitSeedString3 = keccak256(
+            abi.encodePacked(_home2.addr, _home2.playerSeed)
+        );
+        bytes32 commitSeedString4 = keccak256(
+            abi.encodePacked(_visitor2.addr, _visitor2.playerSeed)
+        );
+
+        // home commit playerSeed
+        vm.prank(_home1.addr);
+        bf.commitPlayerSeed(commitSeedString1);
+        // visitor commit playerSeed
+        vm.prank(_visitor1.addr);
+        bf.commitPlayerSeed(commitSeedString2);
+
+        // home commit playerSeed
+        vm.prank(_home2.addr);
+        bf.commitPlayerSeed(commitSeedString3);
+        // visitor commit playerSeed
+        vm.prank(_visitor2.addr);
+        bf.commitPlayerSeed(commitSeedString4);
+
+        uint8 roundCount = 0;
+        IPLMBattleField.BattleState bs1 = manager.getBattleState(_home1.addr);
+        IPLMBattleField.BattleState bs2 = manager.getBattleState(_home2.addr);
+
+        while (roundCount < 5) {
+            if (bs1 == IPLMBattleField.BattleState.InRound) {
+                _round(
+                    _home1,
+                    _visitor1,
+                    commitSeedString1,
+                    commitSeedString2,
+                    roundCount
+                );
+            }
+            if (bs2 == IPLMBattleField.BattleState.InRound) {
+                _round(
+                    _home2,
+                    _visitor2,
+                    commitSeedString3,
+                    commitSeedString4,
+                    roundCount
+                );
+            }
+            roundCount++;
+            bs1 = manager.getBattleState(_home1.addr);
+            bs2 = manager.getBattleState(_home2.addr);
+        }
+    }
+
+    function _round(
+        TestPlayer storage _home,
+        TestPlayer storage _visitor,
+        bytes32 _homeCSS,
+        bytes32 _visitorCSS,
+        uint8 _roundCount
+    ) internal {
+        bytes32 commitChoiceString1 = keccak256(
+            abi.encodePacked(
+                _home.addr,
+                _home.levelPoints[_roundCount],
+                _home.choices[_roundCount],
+                _home.bindingFactor
+            )
+        );
+
+        bytes32 commitChoiceString2 = keccak256(
+            abi.encodePacked(
+                _visitor.addr,
+                _visitor.levelPoints[_roundCount],
+                _visitor.choices[_roundCount],
+                _visitor.bindingFactor
+            )
+        );
+
+        // commit choice
+        vm.prank(_home.addr);
+        bf.commitChoice(commitChoiceString1);
+        vm.prank(_visitor.addr);
+        bf.commitChoice(commitChoiceString2);
+
+        if (_home.choices[_roundCount] == IPLMBattleField.Choice.Random) {
+            vm.prank(_home.addr);
+            bf.revealPlayerSeed(_home.playerSeed);
+        }
+        if (_visitor.choices[_roundCount] == IPLMBattleField.Choice.Random) {
+            vm.prank(_visitor.addr);
+            bf.revealPlayerSeed(_visitor.playerSeed);
+        }
+
+        vm.prank(_home.addr);
+        bf.revealChoice(
+            _home.levelPoints[_roundCount],
+            _home.choices[_roundCount],
+            _home.bindingFactor
+        );
+        vm.prank(_visitor.addr);
+        bf.revealChoice(
+            _visitor.levelPoints[_roundCount],
+            _visitor.choices[_roundCount],
+            _visitor.bindingFactor
+        );
+    }
+}

--- a/test/PLMBattleField.t.sol
+++ b/test/PLMBattleField.t.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import {PLMDealer} from "../src/PLMDealer.sol";
+import {PLMCoin} from "../src/PLMCoin.sol";
+import {PLMToken} from "../src/PLMToken.sol";
+import {PLMData} from "../src/PLMData.sol";
+import {PLMBattleManager} from "../src/PLMBattleManager.sol";
+import {PLMMatchOrganizer} from "../src/PLMMatchOrganizer.sol";
+import {PLMBattleField} from "../src/PLMBattleField.sol";
+import {PLMBattleStorage} from "../src/PLMBattleStorage.sol";
+import {PLMTypesV1} from "../src/data-contracts/PLMTypesV1.sol";
+import {PLMLevelsV1} from "../src/data-contracts/PLMLevelsV1.sol";
+
+import {IPLMCoin} from "../src/interfaces/IPLMCoin.sol";
+import {IPLMToken} from "../src/interfaces/IPLMToken.sol";
+import {IPLMDealer} from "../src/interfaces/IPLMDealer.sol";
+import {IPLMData} from "../src/interfaces/IPLMData.sol";
+import {IPLMBattleManager} from "../src/interfaces/IPLMBattleManager.sol";
+import {IPLMMatchOrganizer} from "../src/interfaces/IPLMMatchOrganizer.sol";
+import {IPLMBattleField} from "../src/interfaces/IPLMBattleField.sol";
+import {IPLMBattleStorage} from "../src/interfaces/IPLMBattleStorage.sol";
+import {IPLMTypes} from "../src/interfaces/IPLMTypes.sol";
+import {IPLMLevels} from "../src/interfaces/IPLMLevels.sol";
+
+contract BattleFieldTest is Test {
+    address polylemmer = address(10);
+    uint256 maticForEx = 100000 ether;
+    uint256 currentBlock = 0;
+
+    PLMCoin coinContract;
+    PLMToken tokenContract;
+    PLMDealer dealerContract;
+    PLMData dataContract;
+
+    PLMTypesV1 typesContract;
+    PLMLevelsV1 levelsContract;
+
+    IPLMToken token;
+    IPLMCoin coin;
+    IPLMDealer dealer;
+    IPLMData data;
+    IPLMTypes types;
+    IPLMLevels levels;
+    IPLMBattleStorage strg;
+    IPLMBattleManager manager;
+
+    PLMBattleStorage strgContract;
+    PLMBattleManager managerContract;
+    PLMMatchOrganizer mo;
+    PLMBattleField bf;
+
+    address home = address(11);
+    address visitor = address(12);
+    address user3 = address(13);
+
+    function setUp() public {
+        // send transaction by deployer
+        vm.startPrank(polylemmer);
+
+        // deploy contract
+        coinContract = new PLMCoin();
+        coin = IPLMCoin(address(coinContract));
+        typesContract = new PLMTypesV1();
+        types = IPLMTypes(address(typesContract));
+        levelsContract = new PLMLevelsV1();
+        levels = IPLMLevels(address(levelsContract));
+        dataContract = new PLMData(types, levels);
+        data = IPLMData(address(dataContract));
+        tokenContract = new PLMToken(coin, data, 100000);
+        token = IPLMToken(address(tokenContract));
+
+        dealerContract = new PLMDealer(token, coin);
+        dealer = IPLMDealer(address(dealerContract));
+
+        strgContract = new PLMBattleStorage();
+        strg = IPLMBattleStorage(address(strgContract));
+        managerContract = new PLMBattleManager(strg);
+        manager = IPLMBattleManager(address(managerContract));
+        mo = new PLMMatchOrganizer(dealer, token);
+        bf = new PLMBattleField(dealer, token, manager);
+
+        // set dealer
+        coin.setDealer(address(dealerContract));
+        token.setDealer(address(dealerContract));
+        dealer.setMatchOrganizer(address(mo));
+        dealer.setBattleField(address(bf));
+        mo.setPLMBattleField(address(bf));
+        bf.setPLMMatchOrganizer(address(mo));
+        manager.setPLMBattleField(address(bf));
+        strg.setBattleManager(address(manager));
+        vm.stopPrank();
+
+        // set block number to be enough length
+        currentBlock = dealerContract.getStaminaMax() * 300 + 1000;
+        vm.roll(currentBlock);
+        vm.stopPrank();
+
+        // initial mint of PLM
+        uint256 ammount = 1e20;
+        vm.prank(polylemmer);
+        dealerContract.mintAdditionalCoin(ammount);
+
+        // send ether to user address
+        vm.deal(home, 10000000 ether);
+        // (user)  charge MATIC and get PLMcoin
+        vm.prank(home);
+        dealerContract.charge{value: maticForEx}();
+
+        //Prepare characters for debug
+        bytes20[4] memory names1 = [bytes20("a1"), "a2", "a3", "a4"];
+        bytes20[4] memory names2 = [bytes20("b1"), "b2", "b3", "b4"];
+        bytes20[4] memory names3 = [bytes20("c1"), "c2", "c3", "c4"];
+        uint8[4] memory levels1 = [1, 2, 2, 8]; // sum: 13
+        uint8[4] memory levels2 = [3, 4, 5, 2]; // sum: 14
+        uint8[4] memory levels3 = [10, 11, 10, 4]; // sum: 35
+
+        // home
+        for (uint256 i = 0; i < names1.length; i++) {
+            _createCharacter(levels1[i], names1[i], home);
+        }
+
+        // visitor
+        for (uint256 i = 0; i < names2.length; i++) {
+            _createCharacter(levels2[i], names2[i], visitor);
+        }
+
+        // user3
+        for (uint256 i = 0; i < names3.length; i++) {
+            _createCharacter(levels3[i], names3[i], user3);
+        }
+    }
+
+    function _createCharacter(
+        uint256 lev,
+        bytes20 name,
+        address owner
+    ) internal {
+        vm.startPrank(address(dealerContract));
+        uint256 tokenId = token.mint(name);
+        for (uint256 i; i < lev; i++) {
+            coin.approve(address(token), token.getNecessaryExp(tokenId));
+            token.updateLevel(tokenId);
+        }
+
+        token.transferFrom(address(dealerContract), owner, tokenId);
+        vm.stopPrank();
+    }
+
+    function testStartBattle() public {
+        currentBlock++;
+        vm.roll(currentBlock);
+        uint256[4] memory homeFixedSlots = [uint256(1), 2, 3, 4];
+        uint256[4] memory visitorFixedSlots = [uint256(5), 6, 7, 8];
+        vm.prank(address(mo));
+        bf.startBattle(
+            home,
+            visitor,
+            currentBlock,
+            currentBlock,
+            homeFixedSlots,
+            visitorFixedSlots
+        );
+    }
+}

--- a/test/PLMBattleStorageInternal.t.sol
+++ b/test/PLMBattleStorageInternal.t.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+import {Utils} from "../src/lib/Utils.sol";
+import {PLMBattleStorage} from "../src/PLMBattleStorage.sol";
+import {IPLMBattleField} from "../src/interfaces/IPLMBattleField.sol";
+
+contract BattleStorageInternal is Test, PLMBattleStorage {
+    function setUp() public {}
+
+    function testEncodeBattleState() public {
+        IPLMBattleField.BattleState bs = IPLMBattleField.BattleState.Canceled;
+        bytes memory encoded = this._encodeBattleState(bs);
+        // uint256 decoded = Utils.bytesToUint256(encoded);
+        uint256 decoded = uint256(bytes32(encoded));
+        assertEq(uint256(bs), decoded);
+    }
+
+    function testEncodeRoundResult() public {
+        IPLMBattleField.RoundResult memory rr = IPLMBattleField.RoundResult({
+            isDraw: false,
+            winner: address(22),
+            loser: address(23),
+            winnerDamage: 10,
+            loserDamage: 6
+        });
+        bytes memory encoded = this._encodeRoundResult(rr);
+        IPLMBattleField.RoundResult memory decoded = this._decodeRoundResult(
+            encoded
+        );
+        assertEq(
+            encoded,
+            this._encodeRoundResult(decoded),
+            "not decoded properly"
+        );
+    }
+
+    function testEncodeBattleResult() public {
+        IPLMBattleField.BattleResult memory br = IPLMBattleField.BattleResult({
+            numRounds: 4,
+            isDraw: false,
+            winner: address(22),
+            loser: address(23),
+            winnerCount: 10,
+            loserCount: 6
+        });
+        bytes memory encoded = this._encodeBattleResult(br);
+        IPLMBattleField.BattleResult memory decoded = this._decodeBattleResult(
+            encoded
+        );
+        assertEq(
+            encoded,
+            this._encodeBattleResult(decoded),
+            "not decoded properly"
+        );
+    }
+
+    function testEncodeCommitChoice() public {
+        IPLMBattleField.ChoiceCommit memory cc = IPLMBattleField.ChoiceCommit({
+            commitString: "sdasodhwkdfjkhdjkflhjh",
+            levelPoint: 19,
+            choice: IPLMBattleField.Choice.Fixed3
+        });
+        bytes memory encoded = this._encodeChoiceCommit(cc);
+        IPLMBattleField.ChoiceCommit memory decoded = this._decodeChoiceCommit(
+            encoded
+        );
+        assertEq(
+            encoded,
+            this._encodeChoiceCommit(decoded),
+            "not decoded properly"
+        );
+    }
+
+    function testEncodePlayerSeedCommit() public {
+        IPLMBattleField.PlayerSeedCommit memory psc = IPLMBattleField
+            .PlayerSeedCommit({
+                commitString: "asdasjlkfhdwjkfh",
+                playerSeed: "djlkfhohovwfoe12138924hfdh"
+            });
+        bytes memory encoded = this._encodePlayerSeedCommit(psc);
+        IPLMBattleField.PlayerSeedCommit memory decoded = this
+            ._decodePlayerSeedCommit(encoded);
+        assertEq(
+            encoded,
+            this._encodePlayerSeedCommit(decoded),
+            "not decoded properly"
+        );
+    }
+
+    function testEncodePlayerInfo() public {
+        IPLMBattleField.PlayerInfo memory pi = IPLMBattleField.PlayerInfo({
+            addr: address(12072),
+            fromBlock: 10,
+            fixedSlots: [uint256(1), 9, 21, 32],
+            fixedSlotsUsedRounds: [uint8(2), 1, 4, 3],
+            randomSlot: IPLMBattleField.RandomSlot({
+                level: 28,
+                nonce: 0x3234333478636473666473000000000000000000000000000000000000000000,
+                usedRound: 3,
+                state: IPLMBattleField.RandomSlotState.Revealed
+            }),
+            state: IPLMBattleField.PlayerState.Standby,
+            winCount: 1,
+            maxLevelPoint: 10,
+            remainingLevelPoint: 23
+        });
+        bytes memory encoded = this._encodePlayerInfo(pi);
+        IPLMBattleField.PlayerInfo memory decoded = this._decodePlayerInfo(
+            encoded
+        );
+        assertEq(
+            encoded,
+            this._encodePlayerInfo(decoded),
+            "not decoded properly"
+        );
+    }
+}

--- a/test/playground.t.sol
+++ b/test/playground.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+
+contract Playground is Test {
+    function setUp() public {}
+
+    function testPlayground() public {
+        uint256 a256 = 255;
+        uint16 a16 = 255;
+        uint8 a8 = 255;
+        bool bi = true;
+        // bool
+        // address
+        // string
+
+        bytes memory b256 = abi.encode(a256);
+        bytes memory b16 = abi.encode(a16);
+        bytes memory b8 = abi.encode(a8);
+        bytes memory biByte = abi.encode(bi);
+
+        console.logBytes(b256);
+        console.logBytes(b16);
+        console.logBytes(b8);
+        console.logBytes(biByte);
+    }
+}


### PR DESCRIPTION
# Description

- src/PLMBattleStorage.sol (ADD)
  - バトルに関連する情報をsstore2で write/readするコントラクト
  - sstore2で格納するにあたり，全てのデータはbytes memory の形で w/r されるので，to/from bytes の変換を行う関数．
  - sstore2でデータを格納すると返ってくるポインタを格納したmapping．readするときに使う．
  - test : test/PLMBattleStorageInternal.t.sol は，bytes への encode, decodeの関数をテストしている．
- src/PLMBattleManager.sol (ADD)
  - BattleFieldコントラクトは，BattleStorageを直接callせず，このBattleManagerの関数を call することで，データの読み書きを行う．battleIdや roundのインデックスを使って参照し，構造体などの部分的な変更など，BattleStorageを直接叩くと処理が嵩むものをラップしている．
  -  test: これそのもののテストは書いていない．BattleFieldが動くことを持ってテストとした．
- src/PLMBattleField.sol (MOD)
  - バトルの情報を格納していたmappingを全て削除．各playerがプレイしている最新のbattleIdを格納するmappingを追加．
  - バトルに関する変数は全てBattleManagerを介したBattleStorageへの書き込みに置き換えた．
  - BattleFieldに実装されたexternal関数の引数は全て変えていないので，フロントからそのまま叩けるはず．
  - ただ，battleIdの指定にmsg.senderを使っているので，callerを間違えると欲しいデータが取れない．
  - **大事** : anvilにデプロイしようとするとcontract size limit に引っかかるので，またサイズの削減が必要．
    - これはManagerを直接呼べばいい関数に関してはManagerに実装し直すことで対応できると思っている．（ただしフロントと協力する必要あり）

なお，マッチメイクの部分は，今の実装のままで，
- １人が同時に２つのバトルを提案，申込できない
が達成されていたので，変更していない（MatchStateで排他制御されてる．） 
 
- test/IntegrationMultiSlot.t.sol (ADD)
  -  testMakeProposalByTwo : 二人同時にバトルを提案し，申込みが入る時の排他制御ができているか，  
  - testMultiSlotBattle: ２つのバトルを同時にスタートさせ，battleId:1のラウンド１ =>battleId:２のラウンド１という風に交互にラウンドを走らせてちゃんと最後までバトルが進むか．（１つ１つのアクションレベルでmultithreadなテストは探索範囲が広すぎて書けないので，これはプレイしてtestする必要あり．）

- PLMMatchOrganizer.t.sol (FIX)
  - testProperBattleFlow: try catchでエラーが出ているのにpassしてしまっていたところ，最後assertしていたbattleStateの値をSettledではなくCanceledにしている部分があったことで，がばがばなテストになってたので，直しました．
  - これまでこのガバガバテストでチェックしてしまっていたdevelopブランチは，実行してみて，emitされたeventを見て，正しく動いていることは確認済みです．

# Test
上で新規に作成したテスト，既存のテストに全てPass. 
```
$ forge test
```

# Context

現在，バトルをプレイできる数が１組（２人，１バトル分）になっている．
これはバトル情報を格納・処理するBattleFieldコントラクトの仕様である．
実装方法を変更することで，複数組が同時にバトル可能な仕様にする．
同時に，SSTORE2を使用してstorageの読み書きが多いバトル周りのcallのガス代を削減する．

# TODO
- BattleFIeldのコントラクトサイズリミットを削減
- コメント書く(コード読む上でわからなくなりそうなところは書きました．DocStringが綺麗に書けてません．)
- レビューの反映が終了したらコミットをまとめる


# Checklist

- [x] I opened a draft PR or added the `[WIP]` level if my PR is not ready for review.
- [x] I have reviewed the code by myself.
- [ ] I have assigned an appropriate reviewer for the PR.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests enough to show how your code behaves and that your code works as expected.

# Additional Notes

TODO: Describe any other information you'd like to mention.